### PR TITLE
Ensure that we cope with symlinked files properly

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-0.107.0
+0.108.0
 
 [ignore]
 <PROJECT_ROOT>/coverage

--- a/__examples__/symlinked_checksums_need_updating/a.js
+++ b/__examples__/symlinked_checksums_need_updating/a.js
@@ -1,0 +1,1 @@
+../checksums_need_updating/a.js

--- a/__examples__/symlinked_checksums_need_updating/b.py
+++ b/__examples__/symlinked_checksums_need_updating/b.py
@@ -1,0 +1,1 @@
+../checksums_need_updating/b.py

--- a/__examples__/symlinked_checksums_need_updating/target_does_not_exist.js
+++ b/__examples__/symlinked_checksums_need_updating/target_does_not_exist.js
@@ -1,0 +1,1 @@
+SomethingThatDoesNotExist

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "codecov": "^3.5.0",
         "eslint": "^6.2.2",
         "eslint-plugin-flowtype": "^4.2.0",
-        "flow-bin": "^0.107.0",
+        "flow-bin": "^0.108.0",
         "flow-typed": "^2.6.1",
         "glob": "^7.1.4",
         "jest": "^24.9.0",

--- a/src/__tests__/__snapshots__/integration_test.js.snap
+++ b/src/__tests__/__snapshots__/integration_test.js.snap
@@ -17,7 +17,7 @@ exports[`Integration Tests should report __examples__ parse errors with autoFix:
  WARNING  __examples__/malformed_start/malformed_onlytagid.js:7 Sync-end for 'tagid' found, but there was no corresponding sync-start
  ERROR  __examples__/missing_target/example.js:3 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
  ERROR  __examples__/no_self_reference/example.js:3 Sync-tag 'example_three' cannot target itself
- ERROR  ENOENT: no such file or directory, stat '/Users/jeffyates/git/checksync/__examples__/symlinked_checksums_need_updating/target_does_not_exist.js'
+ ERROR  Cannot parse file: __examples__/symlinked_checksums_need_updating/target_does_not_exist.js
  ERROR  __examples__/unterminated_marker/example_two-b.py:3 Sync-start 'example_two' has no corresponding sync-end
 
 🛑  Aborting tag updates due to parsing errors. Fix these errors and try again."
@@ -39,7 +39,7 @@ exports[`Integration Tests should report __examples__ violations: __examples__ 1
  WARNING  __examples__/malformed_start/malformed_onlytagid.js:7 Sync-end for 'tagid' found, but there was no corresponding sync-start
  ERROR  __examples__/missing_target/example.js:3 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
  ERROR  __examples__/no_self_reference/example.js:3 Sync-tag 'example_three' cannot target itself
- ERROR  ENOENT: no such file or directory, stat '/Users/jeffyates/git/checksync/__examples__/symlinked_checksums_need_updating/target_does_not_exist.js'
+ ERROR  Cannot parse file: __examples__/symlinked_checksums_need_updating/target_does_not_exist.js
  ERROR  __examples__/unterminated_marker/example_two-b.py:3 Sync-start 'example_two' has no corresponding sync-end
  MISMATCH  __examples__/checksums_need_updating/a.js:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (45678 != 209519188)
  MISMATCH  __examples__/checksums_need_updating/b.py:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 252580609)

--- a/src/__tests__/__snapshots__/integration_test.js.snap
+++ b/src/__tests__/__snapshots__/integration_test.js.snap
@@ -17,6 +17,7 @@ exports[`Integration Tests should report __examples__ parse errors with autoFix:
  WARNING  __examples__/malformed_start/malformed_onlytagid.js:7 Sync-end for 'tagid' found, but there was no corresponding sync-start
  ERROR  __examples__/missing_target/example.js:3 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
  ERROR  __examples__/no_self_reference/example.js:3 Sync-tag 'example_three' cannot target itself
+ ERROR  ENOENT: no such file or directory, stat '/Users/jeffyates/git/checksync/__examples__/symlinked_checksums_need_updating/target_does_not_exist.js'
  ERROR  __examples__/unterminated_marker/example_two-b.py:3 Sync-start 'example_two' has no corresponding sync-end
 
 🛑  Aborting tag updates due to parsing errors. Fix these errors and try again."
@@ -38,6 +39,7 @@ exports[`Integration Tests should report __examples__ violations: __examples__ 1
  WARNING  __examples__/malformed_start/malformed_onlytagid.js:7 Sync-end for 'tagid' found, but there was no corresponding sync-start
  ERROR  __examples__/missing_target/example.js:3 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
  ERROR  __examples__/no_self_reference/example.js:3 Sync-tag 'example_three' cannot target itself
+ ERROR  ENOENT: no such file or directory, stat '/Users/jeffyates/git/checksync/__examples__/symlinked_checksums_need_updating/target_does_not_exist.js'
  ERROR  __examples__/unterminated_marker/example_two-b.py:3 Sync-start 'example_two' has no corresponding sync-end
  MISMATCH  __examples__/checksums_need_updating/a.js:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (45678 != 209519188)
  MISMATCH  __examples__/checksums_need_updating/b.py:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 252580609)

--- a/src/__tests__/cli_test.js
+++ b/src/__tests__/cli_test.js
@@ -181,7 +181,56 @@ describe("#run", () => {
             expect(result).toBeFalse();
         });
 
-        it("should return true for other things", () => {
+        it("should exit on unknown arguments starting with -", () => {
+            // Arrange
+            const fakeParsedArgs = {
+                ...defaultArgs,
+                fix: false,
+                comments: "//,#",
+            };
+            jest.spyOn(CheckSync, "default").mockReturnValue({then: jest.fn()});
+            const minimistSpy = jest
+                .spyOn(minimist, "default")
+                .mockReturnValue(fakeParsedArgs);
+            const exitSpy = jest
+                .spyOn(process, "exit")
+                .mockImplementationOnce(() => {});
+            run(__filename);
+            const unknownHandler = minimistSpy.mock.calls[0][1].unknown;
+
+            // Act
+            unknownHandler("--imadethisup");
+
+            // Assert
+            expect(exitSpy).toHaveBeenCalledWith(ErrorCodes.UNKNOWN_ARGS);
+        });
+
+        it("should report unknown arguments starting with -", () => {
+            // Arrange
+            const fakeParsedArgs = {
+                ...defaultArgs,
+                fix: false,
+                comments: "//,#",
+            };
+            jest.spyOn(CheckSync, "default").mockReturnValue({then: jest.fn()});
+            const minimistSpy = jest
+                .spyOn(minimist, "default")
+                .mockReturnValue(fakeParsedArgs);
+            jest.spyOn(process, "exit").mockImplementationOnce(() => {});
+            const logSpy = jest.spyOn(new Logger(null), "error");
+            run(__filename);
+            const unknownHandler = minimistSpy.mock.calls[0][1].unknown;
+
+            // Act
+            unknownHandler("--imadethisup");
+
+            // Assert
+            expect(logSpy).toHaveBeenCalledWith(
+                "Unknown argument: --imadethisup",
+            );
+        });
+
+        it("should return true for non-argument args (i.e. files)", () => {
             // Arrange
             const fakeParsedArgs = {
                 ...defaultArgs,

--- a/src/__tests__/clone-as-unfixable_test.js
+++ b/src/__tests__/clone-as-unfixable_test.js
@@ -1,0 +1,65 @@
+// @flow
+
+import cloneAsUnfixable from "../clone-as-unfixable.js";
+
+import type {FileInfo} from "../types.js";
+
+describe("#cloneAsUnfixable", () => {
+    it.each([null, undefined])(
+        "should return the same value if null/undefined",
+        testCase => {
+            // Arrange
+
+            // Act
+            const result = cloneAsUnfixable(testCase);
+
+            // Assert
+            expect(result).toBe(testCase);
+        },
+    );
+
+    it("should return new object with markers set to unfixable", () => {
+        // Arrange
+        const fileInfo: FileInfo = {
+            aliases: ["file"],
+            markers: {
+                marker1: {
+                    fixable: true,
+                    targets: {},
+                    checksum: "CHECKSUM",
+                    comment: "COMMENT",
+                },
+            },
+        };
+
+        // Act
+        const result = cloneAsUnfixable(fileInfo);
+
+        // Assert
+        expect(result).toEqual({
+            aliases: ["file"],
+            markers: {
+                marker1: {
+                    fixable: false,
+                    targets: {},
+                    checksum: "CHECKSUM",
+                    comment: "COMMENT",
+                },
+            },
+        });
+    });
+
+    it("should share the same aliases array", () => {
+        // Arrange
+        const fileInfo = {
+            aliases: ["file"],
+            markers: {},
+        };
+
+        // Act
+        const result = cloneAsUnfixable(fileInfo);
+
+        // Assert
+        expect(result && result.aliases).toBe(fileInfo.aliases);
+    });
+});

--- a/src/__tests__/generate-marker-edges_test.js
+++ b/src/__tests__/generate-marker-edges_test.js
@@ -25,32 +25,38 @@ describe("#generateMarkerEdges", () => {
         const NullLogger = new Logger();
         const markerCache: MarkerCache = {
             filea: {
-                marker: ({
-                    comment: "//",
-                    fixable: false,
-                    checksum: "",
-                    targets: {
-                        "1": ({
-                            checksum: "5678",
-                            file: "fileb",
-                            declaration: "// sync-start:marker 5678 fileb",
-                        }: Target),
-                    },
-                }: Marker),
+                aliases: [],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: false,
+                        checksum: "",
+                        targets: {
+                            "1": ({
+                                checksum: "5678",
+                                file: "fileb",
+                                declaration: "// sync-start:marker 5678 fileb",
+                            }: Target),
+                        },
+                    }: Marker),
+                },
             },
             fileb: {
-                marker: ({
-                    comment: "//",
-                    fixable: true,
-                    checksum: "",
-                    targets: {
-                        "1": ({
-                            checksum: "1234",
-                            file: "filea",
-                            declaration: "// sync-start:marker 1234 filea",
-                        }: Target),
-                    },
-                }: Marker),
+                aliases: [],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: true,
+                        checksum: "",
+                        targets: {
+                            "1": ({
+                                checksum: "1234",
+                                file: "filea",
+                                declaration: "// sync-start:marker 1234 filea",
+                            }: Target),
+                        },
+                    }: Marker),
+                },
             },
         };
 
@@ -68,32 +74,38 @@ describe("#generateMarkerEdges", () => {
         const NullLogger = new Logger();
         const markerCache: MarkerCache = {
             filea: {
-                marker: ({
-                    comment: "//",
-                    fixable: false,
-                    checksum: "",
-                    targets: {
-                        "1": ({
-                            checksum: "5678",
-                            file: "fileb",
-                            declaration: "// sync-start:marker 5678 fileb",
-                        }: Target),
-                    },
-                }: Marker),
+                aliases: ["filea"],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: false,
+                        checksum: "",
+                        targets: {
+                            "1": ({
+                                checksum: "5678",
+                                file: "fileb",
+                                declaration: "// sync-start:marker 5678 fileb",
+                            }: Target),
+                        },
+                    }: Marker),
+                },
             },
             fileb: {
-                marker: ({
-                    comment: "//",
-                    fixable: true,
-                    checksum: "",
-                    targets: ({
-                        "1": ({
-                            checksum: "1234",
-                            file: "filea",
-                            declaration: "// sync-start:marker 1234 filea",
-                        }: Target),
-                    }: any),
-                }: Marker),
+                aliases: ["fileb"],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: true,
+                        checksum: "",
+                        targets: ({
+                            "1": ({
+                                checksum: "1234",
+                                file: "filea",
+                                declaration: "// sync-start:marker 1234 filea",
+                            }: Target),
+                        }: any),
+                    }: Marker),
+                },
             },
         };
 
@@ -123,18 +135,21 @@ describe("#generateMarkerEdges", () => {
         const errorSpy = jest.spyOn(NullLogger, "error");
         const markerCache: MarkerCache = {
             filea: {
-                marker: ({
-                    comment: "//",
-                    fixable: true,
-                    checksum: "",
-                    targets: {
-                        "1": ({
-                            checksum: "5678",
-                            file: "fileb",
-                            declaration: "// sync-start:marker 5678 fileb",
-                        }: Target),
-                    },
-                }: Marker),
+                aliases: ["filea"],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: true,
+                        checksum: "",
+                        targets: {
+                            "1": ({
+                                checksum: "5678",
+                                file: "fileb",
+                                declaration: "// sync-start:marker 5678 fileb",
+                            }: Target),
+                        },
+                    }: Marker),
+                },
             },
         };
 
@@ -153,26 +168,32 @@ describe("#generateMarkerEdges", () => {
         const errorSpy = jest.spyOn(NullLogger, "error");
         const markerCache: MarkerCache = {
             filea: {
-                marker: ({
-                    comment: "//",
-                    fixable: true,
-                    checksum: "",
-                    targets: {
-                        "1": ({
-                            checksum: "5678",
-                            file: "fileb",
-                            declaration: "// sync-start:marker 5678 fileb",
-                        }: Target),
-                    },
-                }: Marker),
+                aliases: ["filea"],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: true,
+                        checksum: "",
+                        targets: {
+                            "1": ({
+                                checksum: "5678",
+                                file: "fileb",
+                                declaration: "// sync-start:marker 5678 fileb",
+                            }: Target),
+                        },
+                    }: Marker),
+                },
             },
             fileb: {
-                marker: ({
-                    comment: "//",
-                    fixable: true,
-                    checksum: "",
-                    targets: {},
-                }: Marker),
+                aliases: ["fileb"],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: true,
+                        checksum: "",
+                        targets: {},
+                    }: Marker),
+                },
             },
         };
 
@@ -190,32 +211,38 @@ describe("#generateMarkerEdges", () => {
         const NullLogger = new Logger();
         const markerCache: MarkerCache = {
             filea: {
-                marker: ({
-                    comment: "//",
-                    fixable: true,
-                    checksum: "1234",
-                    targets: {
-                        "1": ({
-                            checksum: "5678",
-                            file: "fileb",
-                            declaration: "// sync-start:marker 5678 fileb",
-                        }: Target),
-                    },
-                }: Marker),
+                aliases: ["filea"],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: true,
+                        checksum: "1234",
+                        targets: {
+                            "1": ({
+                                checksum: "5678",
+                                file: "fileb",
+                                declaration: "// sync-start:marker 5678 fileb",
+                            }: Target),
+                        },
+                    }: Marker),
+                },
             },
             fileb: {
-                marker: ({
-                    comment: "//",
-                    fixable: true,
-                    checksum: "5678",
-                    targets: {
-                        "1": ({
-                            checksum: "1234",
-                            file: "filea",
-                            declaration: "// sync-start:marker 1234 filea",
-                        }: Target),
-                    },
-                }: Marker),
+                aliases: ["fileb"],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: true,
+                        checksum: "5678",
+                        targets: {
+                            "1": ({
+                                checksum: "1234",
+                                file: "filea",
+                                declaration: "// sync-start:marker 1234 filea",
+                            }: Target),
+                        },
+                    }: Marker),
+                },
             },
         };
 
@@ -233,32 +260,38 @@ describe("#generateMarkerEdges", () => {
         const NullLogger = new Logger();
         const markerCache: MarkerCache = {
             filea: {
-                marker: ({
-                    comment: "//",
-                    fixable: true,
-                    checksum: "4321",
-                    targets: {
-                        "1": ({
-                            checksum: "5678",
-                            file: "fileb",
-                            declaration: "// sync-start:marker 4321 fileb",
-                        }: Target),
-                    },
-                }: Marker),
+                aliases: ["filea"],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: true,
+                        checksum: "4321",
+                        targets: {
+                            "1": ({
+                                checksum: "5678",
+                                file: "fileb",
+                                declaration: "// sync-start:marker 4321 fileb",
+                            }: Target),
+                        },
+                    }: Marker),
+                },
             },
             fileb: {
-                marker: ({
-                    comment: "//",
-                    fixable: true,
-                    checksum: "8765",
-                    targets: {
-                        "1": ({
-                            checksum: "1234",
-                            file: "filea",
-                            declaration: "// sync-start:marker 1234 filea",
-                        }: Target),
-                    },
-                }: Marker),
+                aliases: ["fileb"],
+                markers: {
+                    marker: ({
+                        comment: "//",
+                        fixable: true,
+                        checksum: "8765",
+                        targets: {
+                            "1": ({
+                                checksum: "1234",
+                                file: "filea",
+                                declaration: "// sync-start:marker 1234 filea",
+                            }: Target),
+                        },
+                    }: Marker),
+                },
             },
         };
 

--- a/src/__tests__/get-markers-from-files_test.js
+++ b/src/__tests__/get-markers-from-files_test.js
@@ -21,6 +21,7 @@ describe("#fromFiles", () => {
         const parseSpy = jest
             .spyOn(ParseFile, "default")
             .mockReturnValue(Promise.resolve());
+        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
         const options: Options = {
             includeGlobs: ["a.js", "b.js"],
             comments: ["//"],
@@ -60,6 +61,7 @@ describe("#fromFiles", () => {
                 }
                 return Promise.resolve(file);
             });
+        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
         jest.spyOn(fs, "existsSync").mockReturnValue(true);
         jest.spyOn(fs, "lstatSync").mockReturnValue({isFile: () => true});
         const pathSpy = jest
@@ -87,6 +89,7 @@ describe("#fromFiles", () => {
             false,
             ["//"],
             NullLogger,
+            null,
         );
         expect(pathSpy).toHaveBeenCalledWith("file.dirname", "b.js");
         expect(ancesdirSpy).toHaveBeenCalledWith("a.js", null);
@@ -103,6 +106,7 @@ describe("#fromFiles", () => {
                 }
                 return Promise.resolve(file);
             });
+        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
         jest.spyOn(fs, "existsSync").mockReturnValue(true);
         jest.spyOn(fs, "lstatSync").mockReturnValue({isFile: () => true});
         jest.spyOn(path, "join").mockImplementation((a, b) => b);
@@ -140,6 +144,7 @@ describe("#fromFiles", () => {
             false,
             ["//"],
             NullLogger,
+            null,
         );
     });
 
@@ -152,6 +157,7 @@ describe("#fromFiles", () => {
                     fixable,
                 }),
         );
+        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
         const options: Options = {
             includeGlobs: ["a.js", "b.js"],
             comments: ["//"],
@@ -171,12 +177,18 @@ describe("#fromFiles", () => {
         // Assert
         expect(result).toStrictEqual({
             "a.js": {
-                file: "a.js",
-                fixable: true,
+                aliases: ["a.js"],
+                markers: {
+                    file: "a.js",
+                    fixable: true,
+                },
             },
             "b.js": {
-                file: "b.js",
-                fixable: true,
+                aliases: ["b.js"],
+                markers: {
+                    file: "b.js",
+                    fixable: true,
+                },
             },
         });
     });
@@ -192,6 +204,7 @@ describe("#fromFiles", () => {
                 return Promise.resolve(file);
             },
         );
+        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
         jest.spyOn(fs, "existsSync").mockReturnValue(true);
         jest.spyOn(fs, "lstatSync").mockReturnValue({isFile: () => true});
         jest.spyOn(path, "join").mockImplementation((a, b) => b);
@@ -215,7 +228,7 @@ describe("#fromFiles", () => {
         // Assert
         expect(result).toStrictEqual({
             "a.js": null,
-            "b.js": "b.js",
+            "b.js": {aliases: ["b.js"], markers: "b.js"},
             "c.js": null,
         });
     });
@@ -231,6 +244,7 @@ describe("#fromFiles", () => {
                 logCb("c.js");
                 return Promise.resolve(file);
             });
+        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
         jest.spyOn(fs, "existsSync").mockImplementation(f => f === "a.js");
         jest.spyOn(fs, "lstatSync").mockReturnValue({isFile: () => true});
         jest.spyOn(path, "join").mockImplementation((a, b) => b);

--- a/src/__tests__/get-markers-from-files_test.js
+++ b/src/__tests__/get-markers-from-files_test.js
@@ -6,6 +6,7 @@ import * as ParseFile from "../parse-file.js";
 import Logger from "../logger.js";
 import * as Ancesdir from "ancesdir";
 import * as CloneAsFixable from "../clone-as-unfixable.js";
+import Format from "../format.js";
 
 import type {Options} from "../types.js";
 
@@ -375,6 +376,7 @@ describe("#fromFiles", () => {
         jest.spyOn(fs, "realpathSync").mockImplementation(a => {
             throw new Error("This isn't a file!");
         });
+        jest.spyOn(Format, "cwdFilePath").mockImplementation(f => f);
         const logSpy = jest.spyOn(NullLogger, "error");
         const options: Options = {
             includeGlobs: ["a.js", "b.js"],
@@ -389,6 +391,6 @@ describe("#fromFiles", () => {
         await getMarkersFromFiles(options, ["a.js", "b.js"], NullLogger);
 
         // Assert
-        expect(logSpy).toHaveBeenCalledWith("This isn't a file!");
+        expect(logSpy).toHaveBeenCalledWith("Cannot parse file: a.js");
     });
 });

--- a/src/__tests__/get-markers-from-files_test.js
+++ b/src/__tests__/get-markers-from-files_test.js
@@ -5,6 +5,7 @@ import getMarkersFromFiles from "../get-markers-from-files.js";
 import * as ParseFile from "../parse-file.js";
 import Logger from "../logger.js";
 import * as Ancesdir from "ancesdir";
+import * as CloneAsFixable from "../clone-as-unfixable.js";
 
 import type {Options} from "../types.js";
 
@@ -278,4 +279,49 @@ describe("#fromFiles", () => {
             expect.any(Function),
         );
     });
+
+    it("should clone existing file markers if the target of a symlink is already parsed", async () => {
+        // Arrange
+        jest.spyOn(ParseFile, "default").mockImplementation(
+            (file, fixable, comments, logger, logCb) => {
+                if (file === "a.js") {
+                    logCb("b.js");
+                    logCb("c.js");
+                }
+                return Promise.resolve(file);
+            },
+        );
+        jest.spyOn(fs, "realpathSync").mockImplementation(a => {
+            if (a === "c.js") {
+                return "a.js";
+            }
+            return a;
+        });
+        jest.spyOn(fs, "existsSync").mockReturnValue(true);
+        jest.spyOn(fs, "lstatSync").mockReturnValue({isFile: () => true});
+        jest.spyOn(path, "join").mockImplementation((a, b) => b);
+        jest.spyOn(path, "normalize").mockImplementation(b => b);
+        const cloneSpy = jest.spyOn(CloneAsFixable, "default");
+        const options: Options = {
+            includeGlobs: ["a.js", "b.js"],
+            comments: ["//"],
+            autoFix: true,
+            rootMarker: null,
+            dryRun: false,
+            excludeGlobs: [],
+        };
+
+        // Act
+        await getMarkersFromFiles(options, ["a.js", "b.js"], NullLogger);
+
+        // Assert
+        expect(cloneSpy).toHaveBeenCalledWith({
+            aliases: ["a.js", "c.js"],
+            markers: "a.js",
+        });
+    });
+
+    it("should clone symlink parsed file markers to real target", () => {});
+
+    it("should log an error if the file doesn't exist", () => {});
 });

--- a/src/__tests__/parse-file_test.js
+++ b/src/__tests__/parse-file_test.js
@@ -47,6 +47,7 @@ describe("#parseFile", () => {
         const NullLogger = new Logger();
         const fakeInterface = {on: jest.fn()};
         fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
         jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null);
         jest.spyOn(readline, "createInterface").mockReturnValueOnce(
             fakeInterface,
@@ -70,7 +71,7 @@ describe("#parseFile", () => {
         // Arrange
         const NullLogger = new Logger();
         const logger = setupFileReferenceLogger();
-        jest.spyOn(fs, "createReadStream").mockImplementationOnce(() => {
+        jest.spyOn(fs, "openSync").mockImplementationOnce(() => {
             throw new Error("ERROR_STRING");
         });
 
@@ -90,6 +91,7 @@ describe("#parseFile", () => {
         const logger = setupFileReferenceLogger();
         const fakeInterface = {on: jest.fn()};
         fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
         jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null);
         jest.spyOn(readline, "createInterface").mockReturnValueOnce(
             fakeInterface,
@@ -110,7 +112,7 @@ describe("#parseFile", () => {
         // Arrange
         const NullLogger = new Logger();
         const mockFileReferenceLogger = setupFileReferenceLogger();
-        jest.spyOn(fs, "createReadStream").mockImplementationOnce(() => {
+        jest.spyOn(fs, "openSync").mockImplementationOnce(() => {
             throw new Error("ERROR_STRING");
         });
 
@@ -128,6 +130,7 @@ describe("#parseFile", () => {
         const mockMarkerParser = setupMarkerParser();
         const fakeInterface = {on: jest.fn()};
         fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
         jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null);
         jest.spyOn(readline, "createInterface").mockReturnValueOnce(
             fakeInterface,
@@ -154,6 +157,7 @@ describe("#parseFile", () => {
         const NullLogger = new Logger();
         const fakeInterface = {on: jest.fn()};
         fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
         jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null);
         jest.spyOn(readline, "createInterface").mockReturnValueOnce(
             fakeInterface,
@@ -190,6 +194,7 @@ describe("#parseFile", () => {
         const NullLogger = new Logger();
         const fakeInterface = {on: jest.fn()};
         fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
         jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null);
         jest.spyOn(readline, "createInterface").mockReturnValueOnce(
             fakeInterface,
@@ -216,6 +221,7 @@ describe("#parseFile", () => {
         const NullLogger = new Logger();
         const fakeInterface = {on: jest.fn()};
         fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
         jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null);
         jest.spyOn(readline, "createInterface").mockReturnValueOnce(
             fakeInterface,
@@ -249,6 +255,7 @@ describe("#parseFile", () => {
         setupMarkerParser();
         const fakeInterface = {on: jest.fn()};
         fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
         jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null);
         jest.spyOn(readline, "createInterface").mockReturnValueOnce(
             fakeInterface,
@@ -299,6 +306,7 @@ describe("#parseFile", () => {
         setupMarkerParser();
         const fakeInterface = {on: jest.fn()};
         fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
         jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null);
         jest.spyOn(readline, "createInterface").mockReturnValueOnce(
             fakeInterface,
@@ -332,6 +340,7 @@ describe("#parseFile", () => {
         const NullLogger = new Logger();
         const fakeInterface = {on: jest.fn()};
         fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
         jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null);
         jest.spyOn(readline, "createInterface").mockReturnValueOnce(
             fakeInterface,

--- a/src/__tests__/process-cache_test.js
+++ b/src/__tests__/process-cache_test.js
@@ -11,56 +11,64 @@ import type {MarkerCache, Marker, Target, Options} from "../types.js";
 describe("#processCache", () => {
     const TestCache: MarkerCache = {
         filea: {
-            marker1: ({
-                comment: "//",
-                fixable: true,
-                checksum: "5678",
-                targets: {
-                    "1": ({
-                        checksum: "MISMATCH!",
-                        file: "fileb",
-                        declaration: "// sync-start:marker1 MISMATCH! fileb",
-                    }: Target),
-                },
-            }: Marker),
-            marker2: ({
-                comment: "//",
-                fixable: true,
-                checksum: "5678",
-                targets: {
-                    "1": ({
-                        checksum: "MISMATCH!",
-                        file: "fileb",
-                        declaration: "// sync-start:marker2 MISMATCH! fileb",
-                    }: Target),
-                },
-            }: Marker),
+            aliases: ["filea"],
+            markers: {
+                marker1: ({
+                    comment: "//",
+                    fixable: true,
+                    checksum: "5678",
+                    targets: {
+                        "1": ({
+                            checksum: "MISMATCH!",
+                            file: "fileb",
+                            declaration:
+                                "// sync-start:marker1 MISMATCH! fileb",
+                        }: Target),
+                    },
+                }: Marker),
+                marker2: ({
+                    comment: "//",
+                    fixable: true,
+                    checksum: "5678",
+                    targets: {
+                        "1": ({
+                            checksum: "MISMATCH!",
+                            file: "fileb",
+                            declaration:
+                                "// sync-start:marker2 MISMATCH! fileb",
+                        }: Target),
+                    },
+                }: Marker),
+            },
         },
         fileb: {
-            marker1: ({
-                comment: "//",
-                fixable: true,
-                checksum: "TARGET_CHECKSUM",
-                targets: {
-                    "1": ({
-                        checksum: "5678",
-                        file: "filea",
-                        declaration: "// sync-start:marker1 5678 filea",
-                    }: Target),
-                },
-            }: Marker),
-            marker2: ({
-                comment: "//",
-                fixable: true,
-                checksum: "TARGET_CHECKSUM",
-                targets: {
-                    "1": ({
-                        checksum: "5678",
-                        file: "filea",
-                        declaration: "// sync-start:marker2 5678 filea",
-                    }: Target),
-                },
-            }: Marker),
+            aliases: ["fileb"],
+            markers: {
+                marker1: ({
+                    comment: "//",
+                    fixable: true,
+                    checksum: "TARGET_CHECKSUM",
+                    targets: {
+                        "1": ({
+                            checksum: "5678",
+                            file: "filea",
+                            declaration: "// sync-start:marker1 5678 filea",
+                        }: Target),
+                    },
+                }: Marker),
+                marker2: ({
+                    comment: "//",
+                    fixable: true,
+                    checksum: "TARGET_CHECKSUM",
+                    targets: {
+                        "1": ({
+                            checksum: "5678",
+                            file: "filea",
+                            declaration: "// sync-start:marker2 5678 filea",
+                        }: Target),
+                    },
+                }: Marker),
+            },
         },
     };
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -27,6 +27,9 @@ export const run = (launchFilePath: string): void => {
     chalk.enabled = true;
 
     const log = new Logger(console);
+
+    // TODO(somewhatabstract): Verbose logging (make sure any caught errors
+    // verbose their error messages)
     const args = minimist(process.argv, {
         boolean: ["update-tags", "dry-run", "help"],
         string: ["comments", "root-marker", "ignore"],

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,6 +26,7 @@ export const run = (launchFilePath: string): void => {
     chalk.level = 3;
     chalk.enabled = true;
 
+    const log = new Logger(console);
     const args = minimist(process.argv, {
         boolean: ["update-tags", "dry-run", "help"],
         string: ["comments", "root-marker", "ignore"],
@@ -47,11 +48,14 @@ export const run = (launchFilePath: string): void => {
             if (arg === launchFilePath) return false;
             // Filter out the command that yarn/npm might install.
             if (arg.endsWith(".bin/checksync")) return false;
+
+            if (arg.startsWith("-")) {
+                log.error(`Unknown argument: ${arg}`);
+                process.exit(ErrorCodes.UNKNOWN_ARGS);
+            }
             return true;
         },
     });
-
-    const log = new Logger(console);
 
     if (args.help) {
         logHelp(log);

--- a/src/clone-as-unfixable.js
+++ b/src/clone-as-unfixable.js
@@ -1,0 +1,29 @@
+// @flow
+
+import type {FileInfo, Markers} from "./types.js";
+
+/**
+ * Copy the given file info, marking markers as unfixable.
+ *
+ * @export
+ * @param {?Markers} markers The markers to be copied.
+ * @returns {?Markers} The copied markers.
+ */
+export default function cloneAsUnfixable(fileInfo: ?FileInfo): ?FileInfo {
+    if (fileInfo == null) {
+        return fileInfo;
+    }
+
+    const {markers, aliases} = fileInfo;
+    const clonedMarkers: Markers = {};
+    for (const key of Object.keys(markers)) {
+        clonedMarkers[key] = {
+            ...markers[key],
+            fixable: false,
+        };
+    }
+    return {
+        markers: clonedMarkers,
+        aliases: aliases,
+    };
+}

--- a/src/error-codes.js
+++ b/src/error-codes.js
@@ -7,6 +7,7 @@ const errorCodes = {
     NO_FILES: 1,
     PARSE_ERRORS: 2,
     DESYNCHRONIZED_BLOCKS: 3,
+    UNKNOWN_ARGS: 4,
 };
 
 export type ErrorCode = $Values<typeof errorCodes>;

--- a/src/generate-marker-edges.js
+++ b/src/generate-marker-edges.js
@@ -66,6 +66,8 @@ export default function* generateMarkerEdges(
         if (targetMarker == null) {
             return null;
         }
+        // We look for a target that points to our file or an alias of our
+        // file - the file is considered its own alias.
         const matchingTargets = Object.entries(targetMarker.targets).filter(
             ([_, target]) => aliases.includes((target: any).file),
         );
@@ -108,9 +110,6 @@ export default function* generateMarkerEdges(
             const targetInfo: ?FileInfo = cache[targetRef.file];
             const targetMarker: ?Marker =
                 targetInfo && targetInfo.markers[markerID];
-
-            // TODO(somewhatabstract): Ensure we take aliases into account
-            // when looking for target.
 
             const targetDetails = getTargetDetail(targetMarker, aliases);
             if (targetDetails == null) {

--- a/src/get-markers-from-files.js
+++ b/src/get-markers-from-files.js
@@ -7,8 +7,9 @@ import path from "path";
 import uniq from "lodash/uniq";
 import parseFile from "./parse-file.js";
 import ancesdir from "ancesdir";
+import cloneAsUnfixable from "./clone-as-unfixable.js";
 
-import type {ILog, MarkerCache, Options} from "./types.js";
+import type {ILog, FileInfo, MarkerCache, Options} from "./types.js";
 
 /**
  * Generate a marker cache from the given files.
@@ -38,19 +39,72 @@ export default async function getMarkersFromFiles(
         return {file: normalizedFileRef, exists};
     };
 
+    const setCacheData = (file: string, info: ?FileInfo) => {
+        cacheData[file] = info;
+        if (info != null) {
+            info.aliases.push(file);
+        }
+    };
+
+    const cacheFiles = async (files: Array<string>, fixable: boolean) => {
+        for (const file of files) {
+            if (cacheData[file] !== undefined) {
+                continue;
+            }
+
+            // This file might be a symlink source or target, so before we parse it,
+            // let's see if we already did.
+            try {
+                const realFilePath = fs.realpathSync(file);
+                if (
+                    realFilePath !== file &&
+                    cacheData[realFilePath] !== undefined
+                ) {
+                    // Close as unfixable, since this file already exists in
+                    // a fixable version, and we don't need to fix it twice.
+                    setCacheData(
+                        file,
+                        cloneAsUnfixable(cacheData[realFilePath]),
+                    );
+                    continue;
+                }
+
+                const fileMarkers = await parseFile(
+                    file,
+                    fixable,
+                    options.comments,
+                    log,
+                    fixable ? fileRef => logFileRef(file, fileRef) : null,
+                );
+                setCacheData(
+                    file,
+                    fileMarkers
+                        ? {
+                              markers: fileMarkers,
+                              aliases: [],
+                          }
+                        : null,
+                );
+
+                // Since this might be a symlink source, let's make sure we store the
+                // markers under its target filepath too.
+                if (realFilePath !== file) {
+                    // Close as unfixable, since this file already exists in
+                    // a fixable version, and we don't need to fix it twice.
+                    setCacheData(
+                        realFilePath,
+                        cloneAsUnfixable(cacheData[file]),
+                    );
+                }
+            } catch (e) {
+                log.error(e.message);
+            }
+        }
+    };
+
     // TODO(somewhatabstract): Use jest-worker and farm parsing out to
     // multiple threads.
-
-    for (const file of files) {
-        const fileMarkers = await parseFile(
-            file,
-            true,
-            options.comments,
-            log,
-            fileRef => logFileRef(file, fileRef),
-        );
-        cacheData[file] = fileMarkers;
-    }
+    await cacheFiles(files, true);
 
     /**
      * In this second pass, we load the files that are not in the original
@@ -58,19 +112,7 @@ export default async function getMarkersFromFiles(
      * deeper (though perhaps repeating till all referenced files are
      * loaded would be a mode folks might want).
      */
-    for (const fileRef of uniq(referencedFiles)) {
-        if (cacheData[fileRef] !== undefined) {
-            continue;
-        }
-
-        const fileMarkers = await parseFile(
-            fileRef,
-            false,
-            options.comments,
-            log,
-        );
-        cacheData[fileRef] = fileMarkers;
-    }
+    await cacheFiles(uniq(referencedFiles), false);
 
     return cacheData;
 }

--- a/src/get-markers-from-files.js
+++ b/src/get-markers-from-files.js
@@ -8,6 +8,7 @@ import uniq from "lodash/uniq";
 import parseFile from "./parse-file.js";
 import ancesdir from "ancesdir";
 import cloneAsUnfixable from "./clone-as-unfixable.js";
+import Format from "./format.js";
 
 import type {ILog, FileInfo, MarkerCache, Options} from "./types.js";
 
@@ -99,7 +100,7 @@ export default async function getMarkersFromFiles(
                     );
                 }
             } catch (e) {
-                log.error(e.message);
+                log.error(`Cannot parse file: ${Format.cwdFilePath(file)}`);
             }
         }
     };

--- a/src/get-markers-from-files.js
+++ b/src/get-markers-from-files.js
@@ -69,6 +69,8 @@ export default async function getMarkersFromFiles(
                     continue;
                 }
 
+                // TODO(somewhatabstract): Use jest-worker and farm parsing out
+                // to  multiple threads/processes.
                 const fileMarkers = await parseFile(
                     file,
                     fixable,
@@ -102,8 +104,8 @@ export default async function getMarkersFromFiles(
         }
     };
 
-    // TODO(somewhatabstract): Use jest-worker and farm parsing out to
-    // multiple threads.
+    // Process the main file set. These are considered "fixable" as they
+    // are the files that our user requested be processed directly.
     await cacheFiles(files, true);
 
     /**

--- a/src/parse-file.js
+++ b/src/parse-file.js
@@ -32,7 +32,7 @@ export default function parseFile(
     fixable: boolean,
     comments: Array<string>,
     log: ILog,
-    normalizeFileRef?: normalizePathFn,
+    normalizeFileRef?: ?normalizePathFn,
 ): Promise<?Markers> {
     const fileRefLogger = new FileReferenceLogger(file, log);
     const markers: Markers = {};
@@ -73,10 +73,15 @@ export default function parseFile(
                 fileRefLogger,
             );
 
+            // Open the file synchronously so we get a nice error if the file
+            // does not exist or errors in some way during open.
+            const fd = fs.openSync(file, "r");
+            const fileStream = fs.createReadStream(file, {fd});
+
             // Start the parsing.
             readline
                 .createInterface({
-                    input: fs.createReadStream(file),
+                    input: fileStream,
                     crlfDelay: Infinity,
                 })
                 .on("line", (line: string) => markerParser.parseLine(line))

--- a/src/process-cache.js
+++ b/src/process-cache.js
@@ -20,6 +20,8 @@ export default async function processCache(
     const fileValidator = autoFix ? validateAndFix : validateAndReport;
     for (const file of Object.keys(cache)) {
         try {
+            // TODO(somewhatabstract): Use jest-worker and farm processing out
+            // to multiple threads/processes.
             if (!(await fileValidator(options, file, cache, log))) {
                 violationFileNames.push(file);
             }

--- a/src/types.js
+++ b/src/types.js
@@ -100,6 +100,11 @@ export type Markers = {
     ...,
 };
 
+export type FileInfo = {
+    aliases: Array<string>,
+    markers: Markers,
+};
+
 /**
  * All the markers we're working with as a map from filepath to its markers.
  */
@@ -107,7 +112,7 @@ export type MarkerCache = {
     /**
      * A file path mapped to the markers within it.
      */
-    [file: string]: ?Markers,
+    [file: string]: ?FileInfo,
     ...,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2576,10 +2576,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@^0.107.0:
-  version "0.107.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.107.0.tgz#b37bfcce51204d35d58f8eb93b3a76b52291e4cc"
-  integrity sha512-hsmwO5Q0+XUXaO2kIKLpleUNNBSFcsGEQGBOTEC/KR/4Ez695I1fweX/ioSjbU4RWhPZhkIqnpbF9opVAauCHg==
+flow-bin@^0.108.0:
+  version "0.108.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.108.0.tgz#6a42c85fd664d23dd937d925851e8e6ab5d71393"
+  integrity sha512-hPEyCP1J8rdhNDfCAA5w7bN6HUNBDcHVg/ABU5JVo0gUFMx+uRewpyEH8LlLBGjVQuIpbaPpaqpoaQhAVyaYww==
 
 flow-typed@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
Fixes #7 

In this update, we allow for file aliases so that they are only parsed and written once, total, and so that tags referencing a symlinked file act as though they reference the actual file.