### PR TITLE
Use minimatch to filter for ignored globs

### DIFF
--- a/flow-typed/npm/minimatch_v3.x.x.js
+++ b/flow-typed/npm/minimatch_v3.x.x.js
@@ -1,0 +1,54 @@
+// flow-typed signature: 045e3888a6e1a621990262b9a98adc35
+// flow-typed version: c6154227d1/minimatch_v3.x.x/flow_>=v0.104.x
+
+type $npm$minimatch$Options = {
+  debug?: boolean,
+  nobrace?: boolean,
+  noglobstar?: boolean,
+  dot?: boolean,
+  noext?: boolean,
+  nocase?: boolean,
+  nonull?: boolean,
+  matchBase?: boolean,
+  nocomment?: boolean,
+  nonegate?: boolean,
+  flipNegate?: boolean,
+  ...
+};
+
+declare module "minimatch" {
+  declare class Minimatch {
+    constructor(pattern: string, options?: $npm$minimatch$Options): Minimatch,
+    set: Array<Array<string | RegExp>>,
+    regexp: null | RegExp, // null until .makeRe() is called
+    negate: boolean,
+    comment: boolean,
+    empty: boolean,
+    makeRe(): RegExp | false,
+    match(name: string): boolean,
+    matchOne(
+      fileArray: Array<string>,
+      patternArray: Array<string>,
+      partial?: boolean
+    ): boolean
+  }
+
+  declare class MinimatchModule {
+    Minimatch: Class<Minimatch>,
+
+    (name: string, pattern: string, options?: $npm$minimatch$Options): boolean,
+
+    filter(
+      pattern: string,
+      options?: $npm$minimatch$Options
+    ): (value: string) => boolean,
+
+    match(
+      list: Array<string>,
+      pattern: string,
+      options?: $npm$minimatch$Options
+    ): Array<string>
+  }
+
+  declare module.exports: MinimatchModule;
+}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "jest-extended": "^0.11.2",
         "jest-worker": "^24.9.0",
         "lodash": "^4.17.15",
+        "minimatch": "^3.0.4",
         "minimist": "^1.2.0",
         "pre-commit": "^1.2.2",
         "prettier": "1.18.2",

--- a/src/get-files.js
+++ b/src/get-files.js
@@ -37,6 +37,8 @@ const removeIgnoredFiles = (
     files: Array<string>,
     excludeGlobs: Array<string>,
 ): Array<string> => {
+    // Since the matchers are going to be applied repeatedly, let's build
+    // minimatch instances and reuse them.
     const matchers = uniq(excludeGlobs).map(glob => new Minimatch(glob));
     return files.filter(file => matchers.every(m => !m.match(file)));
 };
@@ -51,6 +53,5 @@ export default async function getFiles(
     excludeGlobs: Array<string>,
 ): Promise<Array<string>> {
     const includeFiles = await getFilesForGlobs(includeGlobs);
-
     return removeIgnoredFiles(includeFiles, excludeGlobs);
 }


### PR DESCRIPTION
The current implementation was incredibly naïve and slow. By updating to minimatch, we don't look for ignore files on the filesystem, but instead, filter the paths we already got fro `glob`.