### PR TITLE
Make sure node 8 will be recent for when we finally use windows again

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -69,7 +69,7 @@ jobs:
         # TODO(somewhatabstract): Add windows-latest when we have normalized the
         # paths in the snapshots.
         os: [ubuntu-latest, macOS-latest]
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [^8.12.x, 10.x, 12.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [^8.12.x, 10.x, 12.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Summary
Specify node 8 version to workaround Windows issue in Github Actions

Issues
This works around actions/setup-node#27 and actions/virtual-environments#42