### PR TITLE
Ensure fix includes indentation of start tag

### DIFF
--- a/__examples__/checksums_need_updating/a.js
+++ b/__examples__/checksums_need_updating/a.js
@@ -1,6 +1,8 @@
 // This is a a javascript (or similar language) file
 
-// sync-start:update_me 45678 __examples__/checksums_need_updating/b.py
-const someCode = "does a thing";
-console.log(someCode);
-// sync-end:update_me
+export default function test() {
+    // sync-start:update_me 45678 __examples__/checksums_need_updating/b.py
+    const someCode = "does a thing";
+    console.log(someCode);
+    // sync-end:update_me
+}

--- a/src/__tests__/__snapshots__/integration_test.js.snap
+++ b/src/__tests__/__snapshots__/integration_test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Integration Tests should report example checksums_need_updating to match snapshot 1`] = `
-" MISMATCH  __examples__/checksums_need_updating/a.js:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (45678 != 249234014)
- MISMATCH  __examples__/checksums_need_updating/b.py:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 770446101)
+" MISMATCH  __examples__/checksums_need_updating/a.js:4 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (45678 != 249234014)
+ MISMATCH  __examples__/checksums_need_updating/b.py:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:4'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)
 
 <group 🛠  Desynchronized blocks detected. Check them and update as required before resynchronizing: >
   checksync -u __examples__/checksums_need_updating/a.js __examples__/checksums_need_updating/b.py
@@ -11,8 +11,8 @@ exports[`Integration Tests should report example checksums_need_updating to matc
 
 exports[`Integration Tests should report example checksums_need_updating to match snapshot with autofix dryrun 1`] = `
 " INFO  DRY-RUN: Files will not be modified
- MISMATCH  __examples__/checksums_need_updating/a.js:3 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/b.py:3' from 45678 to 249234014.
- MISMATCH  __examples__/checksums_need_updating/b.py:3 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/a.js:3' from 4567 to 770446101.
+ MISMATCH  __examples__/checksums_need_updating/a.js:4 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/b.py:3' from 45678 to 249234014.
+ MISMATCH  __examples__/checksums_need_updating/b.py:3 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/a.js:4' from 4567 to 2050223083.
 <group 2 file(s) would have been fixed. To fix, run: >
   checksync -u __examples__/checksums_need_updating/a.js __examples__/checksums_need_updating/b.py
 <end_group>
@@ -174,8 +174,8 @@ exports[`Integration Tests should report example no_self_reference to match snap
 `;
 
 exports[`Integration Tests should report example symlinked_checksums_need_updating to match snapshot 1`] = `
-" MISMATCH  __examples__/symlinked_checksums_need_updating/a.js:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (45678 != 249234014)
- MISMATCH  __examples__/symlinked_checksums_need_updating/b.py:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 770446101)
+" MISMATCH  __examples__/symlinked_checksums_need_updating/a.js:4 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (45678 != 249234014)
+ MISMATCH  __examples__/symlinked_checksums_need_updating/b.py:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:4'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)
 
 <group 🛠  Desynchronized blocks detected. Check them and update as required before resynchronizing: >
   checksync -u __examples__/symlinked_checksums_need_updating/a.js __examples__/symlinked_checksums_need_updating/b.py
@@ -184,8 +184,8 @@ exports[`Integration Tests should report example symlinked_checksums_need_updati
 
 exports[`Integration Tests should report example symlinked_checksums_need_updating to match snapshot with autofix dryrun 1`] = `
 " INFO  DRY-RUN: Files will not be modified
- MISMATCH  __examples__/symlinked_checksums_need_updating/a.js:3 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/b.py:3' from 45678 to 249234014.
- MISMATCH  __examples__/symlinked_checksums_need_updating/b.py:3 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/a.js:3' from 4567 to 770446101.
+ MISMATCH  __examples__/symlinked_checksums_need_updating/a.js:4 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/b.py:3' from 45678 to 249234014.
+ MISMATCH  __examples__/symlinked_checksums_need_updating/b.py:3 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/a.js:4' from 4567 to 2050223083.
 <group 2 file(s) would have been fixed. To fix, run: >
   checksync -u __examples__/symlinked_checksums_need_updating/a.js __examples__/symlinked_checksums_need_updating/b.py
 <end_group>

--- a/src/__tests__/__snapshots__/integration_test.js.snap
+++ b/src/__tests__/__snapshots__/integration_test.js.snap
@@ -5,6 +5,7 @@ exports[`Integration Tests should report example checksums_need_updating to matc
  MISMATCH  __examples__/checksums_need_updating/b.py:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:4'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)
 
 <group 🛠  Desynchronized blocks detected. Check them and update as required before resynchronizing: >
+  
   checksync -u __examples__/checksums_need_updating/a.js __examples__/checksums_need_updating/b.py
 <end_group>"
 `;
@@ -14,6 +15,7 @@ exports[`Integration Tests should report example checksums_need_updating to matc
  MISMATCH  __examples__/checksums_need_updating/a.js:4 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/b.py:3' from 45678 to 249234014.
  MISMATCH  __examples__/checksums_need_updating/b.py:3 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/a.js:4' from 4567 to 2050223083.
 <group 2 file(s) would have been fixed. To fix, run: >
+  
   checksync -u __examples__/checksums_need_updating/a.js __examples__/checksums_need_updating/b.py
 <end_group>
 🎉  Everything is in sync!"
@@ -27,6 +29,7 @@ exports[`Integration Tests should report example content_after_start to match sn
  MISMATCH  __examples__/content_after_start/c.js:3 Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/b.py:4'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)
 
 <group 🛑  Desynchronized blocks detected and parsing errors found. Fix the errors, update the blocks, then update the sync-start tags using: >
+  
   checksync -u __examples__/content_after_start/a.js __examples__/content_after_start/b.py __examples__/content_after_start/c.js
 <end_group>"
 `;
@@ -143,6 +146,7 @@ exports[`Integration Tests should report example no_checksums to match snapshot 
  MISMATCH  __examples__/no_checksums/example_one-b.py:3 Looks like you changed the target content for sync-tag 'example_one' in '__examples__/no_checksums/example_one-a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)
 
 <group 🛠  Desynchronized blocks detected. Check them and update as required before resynchronizing: >
+  
   checksync -u __examples__/no_checksums/example_one-a.js __examples__/no_checksums/example_one-b.py
 <end_group>"
 `;
@@ -152,6 +156,7 @@ exports[`Integration Tests should report example no_checksums to match snapshot 
  MISMATCH  __examples__/no_checksums/example_one-a.js:3 Updating checksum for sync-tag 'example_one' referencing '__examples__/no_checksums/example_one-b.py:3' from No checksum to 249234014.
  MISMATCH  __examples__/no_checksums/example_one-b.py:3 Updating checksum for sync-tag 'example_one' referencing '__examples__/no_checksums/example_one-a.js:3' from No checksum to 770446101.
 <group 2 file(s) would have been fixed. To fix, run: >
+  
   checksync -u __examples__/no_checksums/example_one-a.js __examples__/no_checksums/example_one-b.py
 <end_group>
 🎉  Everything is in sync!"
@@ -162,6 +167,7 @@ exports[`Integration Tests should report example no_self_reference to match snap
  MISMATCH  __examples__/no_self_reference/example.js:3 Looks like you changed the target content for sync-tag 'example_three' in '__examples__/no_self_reference/example.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)
 
 <group 🛑  Desynchronized blocks detected and parsing errors found. Fix the errors, update the blocks, then update the sync-start tags using: >
+  
   checksync -u __examples__/no_self_reference/example.js
 <end_group>"
 `;
@@ -178,6 +184,7 @@ exports[`Integration Tests should report example symlinked_checksums_need_updati
  MISMATCH  __examples__/symlinked_checksums_need_updating/b.py:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:4'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)
 
 <group 🛠  Desynchronized blocks detected. Check them and update as required before resynchronizing: >
+  
   checksync -u __examples__/symlinked_checksums_need_updating/a.js __examples__/symlinked_checksums_need_updating/b.py
 <end_group>"
 `;
@@ -187,6 +194,7 @@ exports[`Integration Tests should report example symlinked_checksums_need_updati
  MISMATCH  __examples__/symlinked_checksums_need_updating/a.js:4 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/b.py:3' from 45678 to 249234014.
  MISMATCH  __examples__/symlinked_checksums_need_updating/b.py:3 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/a.js:4' from 4567 to 2050223083.
 <group 2 file(s) would have been fixed. To fix, run: >
+  
   checksync -u __examples__/symlinked_checksums_need_updating/a.js __examples__/symlinked_checksums_need_updating/b.py
 <end_group>
 🎉  Everything is in sync!"

--- a/src/__tests__/validate-and-fix_test.js
+++ b/src/__tests__/validate-and-fix_test.js
@@ -65,21 +65,16 @@ describe("#validateAndFix", () => {
             t => `ROOT_REL:${t}`,
         );
         jest.spyOn(GenerateMarkerEdges, "default").mockReturnValue([
-            {
-                BROKEN_DECLARATION: {
-                    fix: "FIXED_DECLARATION",
-                    edge: ({
-                        markerID: "MARKER_ID",
-                        sourceComment: "//",
-                        sourceChecksum: "SRC_CHECKSUM",
-                        sourceDeclaration: "BROKEN_DECLARATION",
-                        sourceLine: "42",
-                        targetFile: "fileb",
-                        targetChecksum: "TARGET_CHECKSUM",
-                        targetLine: "99",
-                    }: MarkerEdge),
-                },
-            },
+            ({
+                markerID: "MARKER_ID",
+                sourceComment: "//",
+                sourceChecksum: "SRC_CHECKSUM",
+                sourceDeclaration: "BROKEN_DECLARATION",
+                sourceLine: "42",
+                targetFile: "fileb",
+                targetChecksum: "TARGET_CHECKSUM",
+                targetLine: "99",
+            }: MarkerEdge),
         ]);
         const finishReadingFile = () => invokeEvent(fakeInterface.on, "close");
 

--- a/src/generate-marker-edges.js
+++ b/src/generate-marker-edges.js
@@ -11,7 +11,7 @@ export type MarkerEdge = {
     +markerID: string,
 
     /**
-     * The line in the source file where the marker is declared.
+     * The line number in the source file where the marker is declared.
      */
     +sourceLine: string,
 
@@ -36,7 +36,7 @@ export type MarkerEdge = {
     +targetFile: string,
 
     /**
-     * The line in the target file where the marker begins.
+     * The line number in the target file where the marker begins.
      */
     +targetLine: string,
 
@@ -68,9 +68,9 @@ export default function* generateMarkerEdges(
         }
         // We look for a target that points to our file or an alias of our
         // file - the file is considered its own alias.
-        const matchingTargets = Object.entries(targetMarker.targets).filter(
-            ([_, target]) => aliases.includes((target: any).file),
-        );
+        const matchingTargets = Object.entries(
+            targetMarker.targets,
+        ).filter(([_, target]) => aliases.includes((target: any).file));
         if (matchingTargets.length === 0) {
             return null;
         }

--- a/src/process-cache.js
+++ b/src/process-cache.js
@@ -41,6 +41,7 @@ export default async function processCache(
                 .join(" ");
 
             const launchCommand = getLaunchString();
+            log.log("");
             if (commentsArg === defaultArgs.comments) {
                 log.log(`${launchCommand} -u ${fileNamesArgs}`);
             } else {

--- a/src/validate-and-fix.js
+++ b/src/validate-and-fix.js
@@ -25,10 +25,21 @@ const formatEdgeFix = (
     sourceFile: string,
     rootMarker: ?string,
     brokenEdge: MarkerEdge,
-): string =>
-    `${brokenEdge.sourceComment} sync-start:${brokenEdge.markerID} ${
-        brokenEdge.targetChecksum
-    } ${rootRelativePath(brokenEdge.targetFile, rootMarker)}`;
+): string => {
+    const startOfComment = brokenEdge.sourceComment
+        ? brokenEdge.sourceDeclaration.indexOf(brokenEdge.sourceComment)
+        : -1;
+    const indent =
+        startOfComment > 0
+            ? brokenEdge.sourceDeclaration.substring(0, startOfComment)
+            : "";
+    return `${indent}${brokenEdge.sourceComment} sync-start:${
+        brokenEdge.markerID
+    } ${brokenEdge.targetChecksum} ${rootRelativePath(
+        brokenEdge.targetFile,
+        rootMarker,
+    )}`;
+};
 
 /**
  * Generate a map edge from broken declaration to fixed declaration.


### PR DESCRIPTION
**Summary**
- Indentation of start tag line is now written out when updating tags
- Output puts blank line before command
- Fixed a bad test case

**Issues**
Fixes #82 
