### PR TITLE
[#219] Make sure we don't bother writing files that don't need updating

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Running the build will execute tests first.
 
 To run `checksync` locally without building, you can use `./bin/checksync.dev.js`.
 
-To run a `checksync` build. use `./bin/checksync.js` instead.
+To run a `checksync` build, use `./bin/checksync.js` instead.
 
 ### Publishing
 

--- a/src/get-markers-from-files.js
+++ b/src/get-markers-from-files.js
@@ -46,7 +46,7 @@ export default async function getMarkersFromFiles(
                     realFilePath !== file &&
                     cacheData[realFilePath] !== undefined
                 ) {
-                    // Close as unfixable, since this file already exists in
+                    // Clone as unfixable, since this file already exists in
                     // a fixable version, and we don't need to fix it twice.
                     setCacheData(
                         file,

--- a/src/validate-and-fix.js
+++ b/src/validate-and-fix.js
@@ -15,7 +15,7 @@ type EdgeMap = {
         fix: string,
         edge: MarkerEdge,
     },
-    ...,
+    ...
 };
 
 /**
@@ -73,8 +73,9 @@ const reportBrokenEdge = (
         Format.violation(
             `${sourceFileRef} Updating checksum for sync-tag '${markerID}' referencing '${cwdRelativePath(
                 targetFile,
-            )}:${targetLine}' from ${sourceChecksum ||
-                NO_CHECKSUM} to ${targetChecksum}.`,
+            )}:${targetLine}' from ${
+                sourceChecksum || NO_CHECKSUM
+            } to ${targetChecksum}.`,
         ),
     );
 };
@@ -90,8 +91,8 @@ const validateAndFix: FileProcessor = (
         // Let's make a lookup of old declaration to new.
         const brokenEdges = Array.from(generateMarkerEdges(file, cache, log));
         if (brokenEdges.length === 0) {
-            // This shouldn't get here, but if it does, yay! Nothing to do.
             resolve(true);
+            return;
         }
 
         const brokenEdgeMap: EdgeMap = brokenEdges


### PR DESCRIPTION
**Summary**
Turns out, when there are no broken edges, we were still opening and writing files when `-u` is specified. That's bad. So, we fixed it.

**Issues**
#219 

**Details**
Also fixed a couple of typos in docs and code.
