### PR TITLE
Add --json and --silent options

### DIFF
--- a/src/__tests__/check-sync_test.js
+++ b/src/__tests__/check-sync_test.js
@@ -29,6 +29,8 @@ describe("#checkSync", () => {
                 dryRun: true,
                 autoFix: true,
                 comments: ["//"],
+                json: false,
+                silent: false,
             },
             NullLogger,
         );
@@ -52,6 +54,8 @@ describe("#checkSync", () => {
                 dryRun: false,
                 autoFix: true,
                 comments: ["//"],
+                json: false,
+                silent: false,
             },
             NullLogger,
         );
@@ -69,12 +73,14 @@ describe("#checkSync", () => {
         const NullLogger = new Logger();
         jest.spyOn(GetFiles, "default").mockReturnValue([]);
         const errorSpy = jest.spyOn(NullLogger, "error");
-        const options = {
+        const options: Options = {
             includeGlobs: ["glob1", "glob2"],
             excludeGlobs: [],
             dryRun: false,
             autoFix: false,
             comments: ["//"],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -94,6 +100,8 @@ describe("#checkSync", () => {
             dryRun: false,
             autoFix: false,
             comments: ["//"],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -117,6 +125,8 @@ describe("#checkSync", () => {
             dryRun: false,
             autoFix: true,
             comments: ["//"],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -145,6 +155,8 @@ describe("#checkSync", () => {
             dryRun: false,
             autoFix: true,
             comments: ["//"],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -170,6 +182,8 @@ describe("#checkSync", () => {
             dryRun: false,
             autoFix: true,
             comments: ["//"],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -195,6 +209,8 @@ describe("#checkSync", () => {
             autoFix: false,
             comments: ["//"],
             rootMarker: "marker",
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -224,6 +240,8 @@ describe("#checkSync", () => {
                 autoFix: false,
                 comments: ["//"],
                 dryRun: false,
+                json: false,
+                silent: false,
             },
             NullLogger,
         );

--- a/src/__tests__/get-markers-from-files_test.js
+++ b/src/__tests__/get-markers-from-files_test.js
@@ -19,7 +19,7 @@ describe("#fromFiles", () => {
         const parseSpy = jest
             .spyOn(ParseFile, "default")
             .mockReturnValue(Promise.resolve());
-        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
+        jest.spyOn(fs, "realpathSync").mockImplementation((a) => a);
         const options: Options = {
             includeGlobs: ["a.js", "b.js"],
             comments: ["//"],
@@ -27,6 +27,8 @@ describe("#fromFiles", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -63,7 +65,7 @@ describe("#fromFiles", () => {
                     referencedFiles: [],
                 });
             });
-        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
+        jest.spyOn(fs, "realpathSync").mockImplementation((a) => a);
         const options: Options = {
             includeGlobs: ["a.js", "b.js"],
             comments: ["//"],
@@ -71,6 +73,8 @@ describe("#fromFiles", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -98,7 +102,7 @@ describe("#fromFiles", () => {
                 }
                 return Promise.resolve({markers: {}, referencedFiles: []});
             });
-        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
+        jest.spyOn(fs, "realpathSync").mockImplementation((a) => a);
         const options: Options = {
             includeGlobs: ["a.js", "b.js"],
             comments: ["//"],
@@ -106,6 +110,8 @@ describe("#fromFiles", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -145,7 +151,7 @@ describe("#fromFiles", () => {
                     referencedFiles: [],
                 }),
         );
-        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
+        jest.spyOn(fs, "realpathSync").mockImplementation((a) => a);
         const options: Options = {
             includeGlobs: ["a.js", "b.js"],
             comments: ["//"],
@@ -153,6 +159,8 @@ describe("#fromFiles", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -194,7 +202,7 @@ describe("#fromFiles", () => {
                 });
             },
         );
-        jest.spyOn(fs, "realpathSync").mockImplementation(a => a);
+        jest.spyOn(fs, "realpathSync").mockImplementation((a) => a);
         const options: Options = {
             includeGlobs: ["a.js", "b.js"],
             comments: ["//"],
@@ -202,6 +210,8 @@ describe("#fromFiles", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -235,7 +245,7 @@ describe("#fromFiles", () => {
                 });
             },
         );
-        jest.spyOn(fs, "realpathSync").mockImplementation(a => {
+        jest.spyOn(fs, "realpathSync").mockImplementation((a) => {
             // When we get to file c.js, which is referenced rather than in the
             // original file set, it is being processed after a and b.
             // We return that it is the same path as a.js, and hence an alias.
@@ -253,6 +263,8 @@ describe("#fromFiles", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -281,7 +293,7 @@ describe("#fromFiles", () => {
                 });
             },
         );
-        jest.spyOn(fs, "realpathSync").mockImplementation(a => {
+        jest.spyOn(fs, "realpathSync").mockImplementation((a) => {
             // When we get to file a.js, which is in the original file set
             // we report that it is a symlink to c.js.
             // This means that after we parse a.js, we'll clone its markers
@@ -299,6 +311,8 @@ describe("#fromFiles", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -313,10 +327,10 @@ describe("#fromFiles", () => {
 
     it("should log an error if the file doesn't exist", async () => {
         // Arrange
-        jest.spyOn(fs, "realpathSync").mockImplementation(a => {
+        jest.spyOn(fs, "realpathSync").mockImplementation((a) => {
             throw new Error("This isn't a file!");
         });
-        jest.spyOn(Format, "cwdFilePath").mockImplementation(f => f);
+        jest.spyOn(Format, "cwdFilePath").mockImplementation((f) => f);
         const logSpy = jest.spyOn(NullLogger, "error");
         const options: Options = {
             includeGlobs: ["a.js", "b.js"],
@@ -325,6 +339,8 @@ describe("#fromFiles", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act

--- a/src/__tests__/integration_test.js
+++ b/src/__tests__/integration_test.js
@@ -55,6 +55,8 @@ describe("Integration Tests", () => {
                     comments: ["//", "#", "{/*"],
                     dryRun: false,
                     excludeGlobs: ["**/excluded/**"],
+                    json: false,
+                    silent: false,
                 },
                 stringLogger,
             );
@@ -79,6 +81,8 @@ describe("Integration Tests", () => {
                     comments: ["//", "#", "{/*"],
                     dryRun: true,
                     excludeGlobs: ["**/excluded/**"],
+                    json: false,
+                    silent: false,
                 },
                 stringLogger,
             );

--- a/src/__tests__/parse-file_test.js
+++ b/src/__tests__/parse-file_test.js
@@ -65,6 +65,8 @@ describe("#parseFile", () => {
             rootMarker: "rootmarker",
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -95,6 +97,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -123,6 +127,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -154,6 +160,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -180,6 +188,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -211,6 +221,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -248,6 +260,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -285,6 +299,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -329,6 +345,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -370,6 +388,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -409,6 +429,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -444,6 +466,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
         const promise = parseFile(options, "file.js", true, NullLogger);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -507,6 +531,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
         const promise = parseFile(options, "file.js", true, NullLogger);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -548,6 +574,8 @@ describe("#parseFile", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act

--- a/src/__tests__/process-cache_test.js
+++ b/src/__tests__/process-cache_test.js
@@ -2,6 +2,7 @@
 import processCache from "../process-cache.js";
 import Logger from "../logger.js";
 import ErrorCodes from "../error-codes.js";
+import FileReferenceLogger from "../file-reference-logger.js";
 
 import * as ValidateAndReport from "../validate-and-report.js";
 import * as ValidateAndFix from "../validate-and-fix.js";
@@ -92,6 +93,8 @@ describe("#processCache", () => {
                 rootMarker: null,
                 dryRun: false,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -102,13 +105,17 @@ describe("#processCache", () => {
                 options,
                 "filea",
                 TestCache,
-                NullLogger,
+                expect.objectContaining(
+                    new FileReferenceLogger("filea", NullLogger, []),
+                ),
             );
             expect(spy).toHaveBeenCalledWith(
                 options,
                 "fileb",
                 TestCache,
-                NullLogger,
+                expect.objectContaining(
+                    new FileReferenceLogger("fileb", NullLogger, []),
+                ),
             );
         });
 
@@ -125,6 +132,8 @@ describe("#processCache", () => {
                 rootMarker: null,
                 dryRun: false,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -147,6 +156,8 @@ describe("#processCache", () => {
                 rootMarker: "marker",
                 dryRun: false,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -170,6 +181,8 @@ describe("#processCache", () => {
                 autoFix: false,
                 dryRun: false,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -198,6 +211,8 @@ describe("#processCache", () => {
                 autoFix: false,
                 dryRun: false,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -228,6 +243,8 @@ describe("#processCache", () => {
                 rootMarker: null,
                 dryRun: false,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -261,6 +278,8 @@ describe("#processCache", () => {
                 rootMarker: null,
                 dryRun: false,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -283,6 +302,8 @@ describe("#processCache", () => {
                 rootMarker: "marker",
                 dryRun: false,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -306,6 +327,8 @@ describe("#processCache", () => {
                 rootMarker: "marker",
                 dryRun: false,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -330,6 +353,8 @@ describe("#processCache", () => {
                 rootMarker: "marker",
                 dryRun: true,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -358,6 +383,8 @@ describe("#processCache", () => {
                 rootMarker: "marker",
                 dryRun: true,
                 excludeGlobs: [],
+                json: false,
+                silent: false,
             };
 
             // Act
@@ -384,6 +411,8 @@ describe("#processCache", () => {
             rootMarker: "marker",
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act
@@ -412,6 +441,8 @@ describe("#processCache", () => {
             rootMarker: null,
             dryRun: false,
             excludeGlobs: [],
+            json: false,
+            silent: false,
         };
 
         // Act

--- a/src/__tests__/validate-and-report_test.js
+++ b/src/__tests__/validate-and-report_test.js
@@ -15,6 +15,8 @@ describe("#validateAndReport", () => {
         autoFix: false,
         comments: [],
         rootMarker: null,
+        json: false,
+        silent: false,
     };
 
     it("should report violation", async () => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -41,7 +41,15 @@ export const run = (launchFilePath: string): void => {
     // TODO(somewhatabstract): Verbose logging (make sure any caught errors
     // verbose their error messages)
     const args = minimist(process.argv, {
-        boolean: ["updateTags", "dryRun", "help", "noIgnoreFile", "verbose"],
+        boolean: [
+            "updateTags",
+            "dryRun",
+            "help",
+            "noIgnoreFile",
+            "verbose",
+            "json",
+            "silent",
+        ],
         string: ["comments", "rootMarker", "ignore", "ignoreFiles"],
         default: {
             ...defaultArgs,
@@ -79,6 +87,10 @@ export const run = (launchFilePath: string): void => {
         },
     });
 
+    if (args.silent === true) {
+        log.mute();
+    }
+
     if (args.help) {
         logHelp(log);
         process.exit(ErrorCodes.SUCCESS);
@@ -115,6 +127,8 @@ export const run = (launchFilePath: string): void => {
             comments,
             rootMarker: (args.rootMarker: any),
             dryRun: args.dryRun === true,
+            json: args.json === true,
+            silent: args.silent === true,
         },
         log,
     ).then((exitCode) => {

--- a/src/default-args.js
+++ b/src/default-args.js
@@ -7,6 +7,8 @@ const defaultArgs = {
     dryRun: false,
     ignoreFiles: ".gitignore",
     noIgnoreFile: false,
+    json: false,
+    silent: false,
 };
 
 export default defaultArgs;

--- a/src/help.js
+++ b/src/help.js
@@ -66,6 +66,11 @@ Where:
                        Ignored if \`--no-ignore-file\` is present.
                        Defaults to \`.gitignore\`.
 
+    \`--json,-j\`          Ouptut errors, warnings, and violations as a JSON
+                       array of objects that can be consumed by other tools.
+                       If paired with \`--update-tags\`, violations will include
+                       a \`'fix'\`.
+
     \`--no-ignore-file\`   When \`true\`, does not use any ignore file. This is
                        useful when the default value for \`--ignore-file\` is not
                        wanted.
@@ -80,6 +85,9 @@ Where:
                        For example, \`--root-marker .gitignore\` would mean
                        the first ancestor directory containing a
                        \`.gitignore\` file.
+
+    \`--silent,-s\`        Prevents output from being logged to the console
+                       except for JSON output.
 
     \`--update-tags,-u\`   Updates tags with incorrect target checksums. This
                        modifies files in place; run with \`--dry-run\` to see what

--- a/src/json-middleware.js
+++ b/src/json-middleware.js
@@ -1,0 +1,22 @@
+// @flow
+import type {Middleware, MiddlewareDatum} from "./types.js";
+
+export default class JsonMiddleware implements Middleware {
+    _data: Array<MiddlewareDatum>;
+
+    constructor() {
+        this._data = [];
+    }
+
+    process(datum: MiddlewareDatum): ?MiddlewareDatum {
+        this._data.push(datum);
+
+        // Returning null prevents following middlewares from running as well
+        // as the usually logging from occurring.
+        return null;
+    }
+
+    output(): string {
+        return JSON.stringify(this._data, null, 4);
+    }
+}

--- a/src/logger.js
+++ b/src/logger.js
@@ -9,6 +9,9 @@ import type {ILog} from "./types.js";
 type MissingInStandardLog = {
     +errorsLogged: boolean,
     +verbose: (() => string) => void,
+    +violation: (message: string) => void,
+    +mute: () => void,
+    +unmute: () => void,
 };
 type StandardLog = $Diff<ILog, MissingInStandardLog>;
 type StandardLogReadOnly = $ReadOnly<StandardLog>;
@@ -17,11 +20,13 @@ export default class Logging implements ILog {
     _logger: ?StandardLogReadOnly;
     _verbose: boolean;
     _errorsLogged: boolean;
+    _silent: boolean;
 
     constructor(logger: ?StandardLogReadOnly, verbose?: boolean) {
         this._logger = logger;
         this._errorsLogged = false;
         this._verbose = !!verbose;
+        this._silent = false;
     }
 
     setVerbose: () => boolean = () => (this._verbose = true);
@@ -31,33 +36,55 @@ export default class Logging implements ILog {
     }
 
     group: (...labels: Array<string>) => void = (...labels: Array<string>) => {
-        this._logger && this._logger.group(...labels);
+        !this._silent && this._logger && this._logger.group(...labels);
     };
 
     groupEnd: () => void = () => {
-        this._logger && this._logger.groupEnd();
+        !this._silent && this._logger && this._logger.groupEnd();
     };
 
     log: (message: string) => void = (message: string): void => {
-        this._logger && this._logger.log(message);
+        !this._silent && this._logger && this._logger.log(message);
     };
 
     info: (message: string) => void = (message: string): void => {
-        this._logger && this._logger.info(Format.info(message));
+        !this._silent &&
+            this._logger &&
+            this._logger.info(Format.info(message));
     };
 
     error: (message: string) => void = (message: string): void => {
         this._errorsLogged = true;
-        this._logger && this._logger.error(Format.error(message));
+        !this._silent &&
+            this._logger &&
+            this._logger.error(Format.error(message));
+    };
+
+    violation: (message: string) => void = (message: string): void => {
+        !this._silent &&
+            this._logger &&
+            this._logger.log(Format.violation(message));
     };
 
     warn: (message: string) => void = (message: string): void => {
-        this._logger && this._logger.warn(Format.warn(message));
+        !this._silent &&
+            this._logger &&
+            this._logger.warn(Format.warn(message));
     };
 
     verbose: (messageBuilder: () => string) => void = (
         messageBuilder: () => string,
     ): void => {
-        this._verbose && this.log(Format.verbose(messageBuilder()));
+        !this._silent &&
+            this._verbose &&
+            this.log(Format.verbose(messageBuilder()));
+    };
+
+    mute: () => void = () => {
+        this._silent = true;
+    };
+
+    unmute: () => void = () => {
+        this._silent = false;
     };
 }

--- a/src/types.js
+++ b/src/types.js
@@ -22,15 +22,52 @@ export interface ILog {
     +error: (message: string) => void;
     +info: (message: string) => void;
     +log: (message: string) => void;
+    +violation: (message: string) => void;
     +warn: (message: string) => void;
     +verbose: (() => string) => void;
+    +mute: () => void;
+    +unmute: () => void;
 }
 
 export interface IPositionLog extends ILog {
     +error: (message: string, line?: string | number) => void;
     +info: (message: string, line?: string | number) => void;
     +log: (message: string, line?: string | number) => void;
+    +violation: (message: string, line?: string | number, fix?: string) => void;
     +warn: (message: string, line?: string | number) => void;
+}
+
+export type MiddlewareDatum =
+    | {
+          type: "error",
+          message: string,
+          line?: string | number,
+      }
+    | {
+          type: "info",
+          message: string,
+          line?: string | number,
+      }
+    | {
+          type: "log",
+          message: string,
+          line?: string | number,
+      }
+    | {
+          type: "violation",
+          message: string,
+          line?: string | number,
+          fix?: string,
+      }
+    | {
+          type: "warn",
+          message: string,
+          line?: string | number,
+      };
+
+// Middlewares can't affect the operation of what's reported or not.
+export interface Middleware {
+    +process: (data: MiddlewareDatum) => ?MiddlewareDatum;
 }
 
 /**
@@ -132,12 +169,10 @@ export type FileProcessor = (
     options: Options,
     file: string,
     cache: $ReadOnly<MarkerCache>,
-    log: ILog,
+    log: IPositionLog,
 ) => Promise<boolean>;
 
-export type normalizePathFn = (
-    relativeFile: string,
-) => ?{
+export type normalizePathFn = (relativeFile: string) => ?{
     file: string,
     exists: boolean,
 };
@@ -148,6 +183,8 @@ export type Options = {
     autoFix: boolean,
     comments: Array<string>,
     dryRun: boolean,
+    json: boolean,
+    silent: boolean,
     rootMarker?: ?string,
 };
 

--- a/src/validate-and-report.js
+++ b/src/validate-and-report.js
@@ -3,13 +3,18 @@ import Format from "./format.js";
 import cwdRelativePath from "./cwd-relative-path.js";
 import generateMarkerEdges from "./generate-marker-edges.js";
 
-import type {MarkerCache, ILog, Options, FileProcessor} from "./types.js";
+import type {
+    MarkerCache,
+    IPositionLog,
+    Options,
+    FileProcessor,
+} from "./types.js";
 import type {MarkerEdge} from "./generate-marker-edges.js";
 
 const reportBrokenEdge = (
     sourceFile: string,
     brokenEdge: MarkerEdge,
-    log: ILog,
+    log: IPositionLog,
 ): void => {
     const {
         markerID,
@@ -22,14 +27,14 @@ const reportBrokenEdge = (
 
     const NO_CHECKSUM = "No checksum";
     const sourceFileRef = Format.cwdFilePath(`${sourceFile}:${sourceLine}`);
-    const checksums = `${sourceChecksum || NO_CHECKSUM} != ${targetChecksum ||
-        NO_CHECKSUM}`;
-    log.log(
-        Format.violation(
-            `${sourceFileRef} Looks like you changed the target content for sync-tag '${markerID}' in '${cwdRelativePath(
-                targetFile,
-            )}:${targetLine}'. Make sure you've made the parallel changes in the source file, if necessary (${checksums})`,
-        ),
+    const checksums = `${sourceChecksum || NO_CHECKSUM} != ${
+        targetChecksum || NO_CHECKSUM
+    }`;
+    log.violation(
+        `${sourceFileRef} Looks like you changed the target content for sync-tag '${markerID}' in '${cwdRelativePath(
+            targetFile,
+        )}:${targetLine}'. Make sure you've made the parallel changes in the source file, if necessary (${checksums})`,
+        targetLine,
     );
 };
 
@@ -37,7 +42,7 @@ const validateAndReport: FileProcessor = (
     options: Options,
     file: string,
     cache: $ReadOnly<MarkerCache>,
-    log: ILog,
+    log: IPositionLog,
 ): Promise<boolean> => {
     let fileNeedsFixing = false;
     for (const brokenEdge of generateMarkerEdges(file, cache, log)) {


### PR DESCRIPTION
**Summary**
This PR adds `--json` and `--silent` options.  The `--json` option provides a way to get structured output that's easy to parse by other tools, e.g. and eslint rule I'm going to be working on.  The `--silent` option hides all output except for the JSON output.  This makes it easier for other tooling to consume the output.

**Details**
I facilitated the collection of data necessary for the JSON output by introducing the concept of middleware.  `FileReferenceLogger` uses the `JsonMiddleware` to collects an array of objects corresponding to the violations and errors that it logs.  Later on, process-cache.js logs the result of the middleware's `.output()` method which coverts the array to a JSON string.

**Issue** #634

**Review notes**
This is a draft PR at the moment.  There's still a number of tests that are failing and I wanted to get feedback on the overall design before working on fixing the tests.