### PR TITLE
All Errors handled by file validators

### DIFF
--- a/src/__tests__/__snapshots__/integration_test.js.snap
+++ b/src/__tests__/__snapshots__/integration_test.js.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration Tests should report example checksums_need_updating to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example checksums_need_updating to match snapshot 1`
+] = `
 " MISMATCH  __examples__/checksums_need_updating/a.js:4 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (45678 != 249234014)
  MISMATCH  __examples__/checksums_need_updating/a.js:5 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/c.jsx:3'. Make sure you've made the parallel changes in the source file, if necessary (1234 != 1992689801)
  MISMATCH  __examples__/checksums_need_updating/b.py:3 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:4'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)
@@ -12,7 +14,9 @@ exports[`Integration Tests should report example checksums_need_updating to matc
 <end_group>"
 `;
 
-exports[`Integration Tests should report example checksums_need_updating to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example checksums_need_updating to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  MISMATCH  __examples__/checksums_need_updating/a.js:4 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/b.py:3' from 45678 to 249234014.
  MISMATCH  __examples__/checksums_need_updating/a.js:5 Updating checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/c.jsx:3' from 1234 to 1992689801.
@@ -25,7 +29,9 @@ exports[`Integration Tests should report example checksums_need_updating to matc
 🎉  Everything is in sync!"
 `;
 
-exports[`Integration Tests should report example content_after_start to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example content_after_start to match snapshot 1`
+] = `
 " ERROR  __examples__/content_after_start/c.js:5 Sync-start for 'content_after_start' found after content started
  MISMATCH  __examples__/content_after_start/a.js:3 Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)
  MISMATCH  __examples__/content_after_start/b.py:3 Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)
@@ -38,51 +44,71 @@ exports[`Integration Tests should report example content_after_start to match sn
 <end_group>"
 `;
 
-exports[`Integration Tests should report example content_after_start to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example content_after_start to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  ERROR  __examples__/content_after_start/c.js:5 Sync-start for 'content_after_start' found after content started
 
 🛑  Aborting tag updates due to parsing errors. Fix these errors and try again."
 `;
 
-exports[`Integration Tests should report example correct_checksums to match snapshot 1`] = `"🎉  Everything is in sync!"`;
+exports[
+    `Integration Tests should report example correct_checksums to match snapshot 1`
+] = `"🎉  Everything is in sync!"`;
 
-exports[`Integration Tests should report example correct_checksums to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example correct_checksums to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
 🎉  Everything is in sync!"
 `;
 
-exports[`Integration Tests should report example directory_target to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example directory_target to match snapshot 1`
+] = `
 " ERROR  __examples__/directory_target/example.js:3 Sync-start for 'directory_target' points to '__examples__/directory_target/a_directory', which does not exist or is a directory
 🛑  Errors occurred during processing"
 `;
 
-exports[`Integration Tests should report example directory_target to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example directory_target to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  ERROR  __examples__/directory_target/example.js:3 Sync-start for 'directory_target' points to '__examples__/directory_target/a_directory', which does not exist or is a directory
 
 🛑  Aborting tag updates due to parsing errors. Fix these errors and try again."
 `;
 
-exports[`Integration Tests should report example end_with_no_start to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example end_with_no_start to match snapshot 1`
+] = `
 " WARNING  __examples__/end_with_no_start/example.js:5 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 🎉  Everything is in sync!"
 `;
 
-exports[`Integration Tests should report example end_with_no_start to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example end_with_no_start to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  WARNING  __examples__/end_with_no_start/example.js:5 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 🎉  Everything is in sync!"
 `;
 
-exports[`Integration Tests should report example excluded to match snapshot 1`] = `" ERROR  No matching files"`;
+exports[
+    `Integration Tests should report example excluded to match snapshot 1`
+] = `" ERROR  No matching files"`;
 
-exports[`Integration Tests should report example excluded to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example excluded to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  ERROR  No matching files"
 `;
 
-exports[`Integration Tests should report example malformed_end to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example malformed_end to match snapshot 1`
+] = `
 " ERROR  __examples__/malformed_end/malformed_badid.js:7 Malformed sync-end: format should be 'sync-end:<label>'
  ERROR  __examples__/malformed_end/malformed_badid.js:4 Sync-start 'tagid' has no corresponding sync-end
  ERROR  __examples__/malformed_end/malformed_noid.js:7 Malformed sync-end: format should be 'sync-end:<label>'
@@ -90,7 +116,9 @@ exports[`Integration Tests should report example malformed_end to match snapshot
 🛑  Errors occurred during processing"
 `;
 
-exports[`Integration Tests should report example malformed_end to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example malformed_end to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  ERROR  __examples__/malformed_end/malformed_badid.js:7 Malformed sync-end: format should be 'sync-end:<label>'
  ERROR  __examples__/malformed_end/malformed_badid.js:4 Sync-start 'tagid' has no corresponding sync-end
@@ -100,7 +128,9 @@ exports[`Integration Tests should report example malformed_end to match snapshot
 🛑  Aborting tag updates due to parsing errors. Fix these errors and try again."
 `;
 
-exports[`Integration Tests should report example malformed_start to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example malformed_start to match snapshot 1`
+] = `
 " ERROR  __examples__/malformed_start/malformed_badchecksum.js:4 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
  WARNING  __examples__/malformed_start/malformed_badchecksum.js:7 Sync-end for 'tagid' found, but there was no corresponding sync-start
  ERROR  __examples__/malformed_start/malformed_badid.js:4 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
@@ -110,7 +140,9 @@ exports[`Integration Tests should report example malformed_start to match snapsh
 🛑  Errors occurred during processing"
 `;
 
-exports[`Integration Tests should report example malformed_start to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example malformed_start to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  ERROR  __examples__/malformed_start/malformed_badchecksum.js:4 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
  WARNING  __examples__/malformed_start/malformed_badchecksum.js:7 Sync-end for 'tagid' found, but there was no corresponding sync-start
@@ -122,30 +154,48 @@ exports[`Integration Tests should report example malformed_start to match snapsh
 🛑  Aborting tag updates due to parsing errors. Fix these errors and try again."
 `;
 
-exports[`Integration Tests should report example missing_target to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example missing_target to match snapshot 1`
+] = `
 " ERROR  __examples__/missing_target/example.js:3 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
 🛑  Errors occurred during processing"
 `;
 
-exports[`Integration Tests should report example missing_target to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example missing_target to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  ERROR  __examples__/missing_target/example.js:3 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
 
 🛑  Aborting tag updates due to parsing errors. Fix these errors and try again."
 `;
 
-exports[`Integration Tests should report example no_back_reference to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example no_back_reference to match snapshot 1`
+] = `
 " ERROR  __examples__/no_back_reference/file2.js does not contain a tag named 'markerID' that points to '__examples__/no_back_reference/file1.js'
-🛑  Errors occurred during processing"
+
+<group 🛑  Desynchronized blocks detected and parsing errors found. Fix the errors, update the blocks, then update the sync-start tags using: >
+  
+  checksync -c \\"#,//,{/*\\" -u __examples__/no_back_reference/file1.js
+<end_group>"
 `;
 
-exports[`Integration Tests should report example no_back_reference to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example no_back_reference to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  ERROR  __examples__/no_back_reference/file2.js does not contain a tag named 'markerID' that points to '__examples__/no_back_reference/file1.js'
+<group 1 file(s) would have been fixed. To fix, run: >
+  
+  checksync -c \\"#,//,{/*\\" -u __examples__/no_back_reference/file1.js
+<end_group>
 🛑  Errors occurred during processing"
 `;
 
-exports[`Integration Tests should report example no_checksums to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example no_checksums to match snapshot 1`
+] = `
 " MISMATCH  __examples__/no_checksums/example_one-a.js:3 Looks like you changed the target content for sync-tag 'example_one' in '__examples__/no_checksums/example_one-b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)
  MISMATCH  __examples__/no_checksums/example_one-b.py:3 Looks like you changed the target content for sync-tag 'example_one' in '__examples__/no_checksums/example_one-a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)
 
@@ -155,7 +205,9 @@ exports[`Integration Tests should report example no_checksums to match snapshot 
 <end_group>"
 `;
 
-exports[`Integration Tests should report example no_checksums to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example no_checksums to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  MISMATCH  __examples__/no_checksums/example_one-a.js:3 Updating checksum for sync-tag 'example_one' referencing '__examples__/no_checksums/example_one-b.py:3' from No checksum to 249234014.
  MISMATCH  __examples__/no_checksums/example_one-b.py:3 Updating checksum for sync-tag 'example_one' referencing '__examples__/no_checksums/example_one-a.js:3' from No checksum to 770446101.
@@ -166,7 +218,9 @@ exports[`Integration Tests should report example no_checksums to match snapshot 
 🎉  Everything is in sync!"
 `;
 
-exports[`Integration Tests should report example no_self_reference to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example no_self_reference to match snapshot 1`
+] = `
 " ERROR  __examples__/no_self_reference/example.js:3 Sync-tag 'example_three' cannot target itself
  MISMATCH  __examples__/no_self_reference/example.js:3 Looks like you changed the target content for sync-tag 'example_three' in '__examples__/no_self_reference/example.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)
 
@@ -176,20 +230,30 @@ exports[`Integration Tests should report example no_self_reference to match snap
 <end_group>"
 `;
 
-exports[`Integration Tests should report example no_self_reference to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example no_self_reference to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  ERROR  __examples__/no_self_reference/example.js:3 Sync-tag 'example_three' cannot target itself
 
 🛑  Aborting tag updates due to parsing errors. Fix these errors and try again."
 `;
 
-exports[`Integration Tests should report example unterminated_marker to match snapshot 1`] = `
+exports[
+    `Integration Tests should report example unterminated_marker to match snapshot 1`
+] = `
 " ERROR  __examples__/unterminated_marker/example_two-b.py:3 Sync-start 'example_two' has no corresponding sync-end
  ERROR  __examples__/unterminated_marker/example_two-b.py does not contain a tag named 'example_two' that points to '__examples__/unterminated_marker/example_two-a.js'
-🛑  Errors occurred during processing"
+
+<group 🛑  Desynchronized blocks detected and parsing errors found. Fix the errors, update the blocks, then update the sync-start tags using: >
+  
+  checksync -c \\"#,//,{/*\\" -u __examples__/unterminated_marker/example_two-a.js
+<end_group>"
 `;
 
-exports[`Integration Tests should report example unterminated_marker to match snapshot with autofix dryrun 1`] = `
+exports[
+    `Integration Tests should report example unterminated_marker to match snapshot with autofix dryrun 1`
+] = `
 " INFO  DRY-RUN: Files will not be modified
  ERROR  __examples__/unterminated_marker/example_two-b.py:3 Sync-start 'example_two' has no corresponding sync-end
 

--- a/src/__tests__/marker-parser_test.js
+++ b/src/__tests__/marker-parser_test.js
@@ -253,13 +253,13 @@ describe("MarkerParser", () => {
                 "1284371662",
                 expect.objectContaining({
                     "1": {
-                        checksum: undefined,
+                        checksum: "",
                         declaration: "// sync-start:markerid1 target1",
                         file: "target1",
                     },
                 }),
                 "//",
-                undefined,
+                "",
             );
             expect(addMarker).toHaveBeenCalledWith(
                 "markerid2",
@@ -272,7 +272,7 @@ describe("MarkerParser", () => {
                     },
                 }),
                 "#",
-                undefined,
+                "",
             );
             expect(addMarker).toHaveBeenCalledWith(
                 "markerid3",

--- a/src/__tests__/validate-and-fix_test.js
+++ b/src/__tests__/validate-and-fix_test.js
@@ -45,7 +45,7 @@ describe("#validateAndFix", () => {
         expect(result).toBeTrue();
     });
 
-    it("should resolve false if the target of a tag does not exist", async () => {
+    it("should resolve false where target file does not reference source file", async () => {
         // Arrange
         const NullLogger = new Logger(null);
         const fakeWriteStream = {

--- a/src/__tests__/validate-and-report_test.js
+++ b/src/__tests__/validate-and-report_test.js
@@ -17,7 +17,7 @@ describe("#validateAndReport", () => {
         rootMarker: null,
     };
 
-    it("should report violation", async () => {
+    it("should report checksum mismatch violation", async () => {
         // Arrange
         const NullLogger = new Logger();
         jest.spyOn(GenerateMarkerEdges, "default").mockReturnValue([
@@ -89,7 +89,57 @@ describe("#validateAndReport", () => {
         );
     });
 
-    it("should return true if file has no mismatches", async () => {
+    it("should return false if the target of the tag does not exist", async () => {
+        // Arrange
+        const NullLogger = new Logger();
+        jest.spyOn(GenerateMarkerEdges, "default").mockReturnValue([
+            {
+                markerID: "marker",
+                sourceChecksum: "1234",
+                sourceLine: "1",
+                targetChecksum: undefined,
+                targetFile: "filea",
+                targetLine: undefined,
+            },
+        ]);
+
+        // Act
+        const result = await validateAndReport(
+            options,
+            "fileb",
+            {},
+            NullLogger,
+        );
+
+        // Assert
+        expect(result).toBeFalse();
+    });
+
+    it("should log error if the target of the tag does not exist", async () => {
+        // Arrange
+        const NullLogger = new Logger();
+        jest.spyOn(GenerateMarkerEdges, "default").mockReturnValue([
+            {
+                markerID: "marker",
+                sourceChecksum: "1234",
+                sourceLine: "1",
+                targetChecksum: undefined,
+                targetFile: "filea",
+                targetLine: undefined,
+            },
+        ]);
+        const logSpy = jest.spyOn(NullLogger, "error");
+
+        // Act
+        await validateAndReport(options, "fileb", {}, NullLogger);
+
+        // Assert
+        expect(logSpy).toHaveBeenCalledWith(
+            "filea does not contain a tag named 'marker' that points to 'fileb'",
+        );
+    });
+
+    it("should return true if file has no mismatches or errors", async () => {
         // Arrange
         const NullLogger = new Logger();
         jest.spyOn(GenerateMarkerEdges, "default").mockReturnValue([]);

--- a/src/marker-parser.js
+++ b/src/marker-parser.js
@@ -95,6 +95,13 @@ const targetsFromTrackedTargets = (trackedTargets: TrackedTargets): Targets => {
     return targets;
 };
 
+const TagDecodeGroup = Object.freeze({
+    tagId: 1,
+    checksum: 2,
+    targetFileName: 3,
+    commentEnd: 4,
+});
+
 /**
  * Parser to extract sync markers from lines of text.
  *
@@ -162,6 +169,8 @@ export default class MarkerParser {
          *     2: The checksum (optional)
          *     3: The target filename
          *     4: The optional comment end
+         *
+         * See `TagDecodeGroup` above.
          */
         this._startTagDecodeRegExp = new RegExp(
             `^([^\\s]+)\\s+([0-9]*)?\\s*(\\S*)(\\s+[^\\s\\w]*)?$`,
@@ -328,13 +337,16 @@ export default class MarkerParser {
                     lineNumber,
                 );
             } else {
+                // Turns out that an empty optional tag group, though typed as
+                // string can actually be undefined. So, for the optional bits
+                // we'll just make sure they get coerced to empty strings.
                 this._recordMarkerStart(
-                    startDecode[1],
-                    startDecode[3],
+                    startDecode[TagDecodeGroup.tagId],
+                    startDecode[TagDecodeGroup.targetFileName],
                     lineNumber,
-                    startDecode[2],
+                    startDecode[TagDecodeGroup.checksum] || "",
                     startMatch[1],
-                    startDecode[4],
+                    startDecode[TagDecodeGroup.commentEnd] || "",
                     content,
                 );
             }

--- a/src/types.js
+++ b/src/types.js
@@ -135,9 +135,7 @@ export type FileProcessor = (
     log: ILog,
 ) => Promise<boolean>;
 
-export type normalizePathFn = (
-    relativeFile: string,
-) => ?{
+export type normalizePathFn = (relativeFile: string) => ?{
     file: string,
     exists: boolean,
 };

--- a/src/validate-and-report.js
+++ b/src/validate-and-report.js
@@ -20,10 +20,22 @@ const reportBrokenEdge = (
         targetChecksum,
     } = brokenEdge;
 
+    if (targetLine == null || targetChecksum == null) {
+        log.error(
+            `${Format.cwdFilePath(
+                targetFile,
+            )} does not contain a tag named '${markerID}' that points to '${cwdRelativePath(
+                sourceFile,
+            )}'`,
+        );
+        return;
+    }
+
     const NO_CHECKSUM = "No checksum";
     const sourceFileRef = Format.cwdFilePath(`${sourceFile}:${sourceLine}`);
-    const checksums = `${sourceChecksum || NO_CHECKSUM} != ${targetChecksum ||
-        NO_CHECKSUM}`;
+    const checksums = `${sourceChecksum || NO_CHECKSUM} != ${
+        targetChecksum || NO_CHECKSUM
+    }`;
     log.log(
         Format.violation(
             `${sourceFileRef} Looks like you changed the target content for sync-tag '${markerID}' in '${cwdRelativePath(
@@ -40,7 +52,7 @@ const validateAndReport: FileProcessor = (
     log: ILog,
 ): Promise<boolean> => {
     let fileNeedsFixing = false;
-    for (const brokenEdge of generateMarkerEdges(file, cache, log)) {
+    for (const brokenEdge of generateMarkerEdges(file, cache)) {
         fileNeedsFixing = true;
         reportBrokenEdge(file, brokenEdge, log);
     }


### PR DESCRIPTION
This changes the `generateMarkerEdges` function to treat missing
target files or markers as broken edges rather than reporting them
directly. The validators have then been updated to understand this
kind of broken edge and report them. This will allow for other kinds
of validators to handle this kind of error with a more helpful message
(such as those that could be used to support linters).

This also addresses an issue that Flow can't catch due to poor core
typing. It turns out that regex optional groups can come back as
undefined in a match, even though the type is a string. So, now
the two optional groups in our tag parsing are coerced to empty strings
in the case that they aren't present (which is what was expected).
