### PR TITLE
Fix handling of cli arg that is symlink

### DIFF
--- a/src/__tests__/cli_test.js
+++ b/src/__tests__/cli_test.js
@@ -2,7 +2,6 @@
 import * as minimist from "minimist";
 
 import fs from "fs";
-import path from "path";
 import {run} from "../cli.js";
 import * as CheckSync from "../check-sync.js";
 import ErrorCodes from "../error-codes.js";
@@ -27,7 +26,6 @@ jest.mock("../logger.js", () => {
 });
 jest.mock("parse-gitignore");
 jest.mock("fs");
-jest.mock("path");
 
 describe("#run", () => {
     it("should parse args", () => {
@@ -367,8 +365,7 @@ describe("#run", () => {
             jest.spyOn(ParseGitIgnore, "default").mockReturnValue([
                 "madeupglob",
             ]);
-            jest.spyOn(fs, "readlinkSync").mockReturnValue("/doesnt/matter");
-            jest.spyOn(path, "resolve").mockReturnValue(
+            jest.spyOn(fs, "realpathSync").mockReturnValue(
                 __filename, // Symlink resolves to our run file
             );
             run(__filename);

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,6 @@
  * The implementation of our command line utility.
  */
 import fs from "fs";
-import path from "path";
 import chalk from "chalk";
 import minimist from "minimist";
 import checkSync from "./check-sync.js";

--- a/src/cli.js
+++ b/src/cli.js
@@ -75,7 +75,7 @@ export const run = (launchFilePath: string): void => {
             if (arg.endsWith(".bin/checksync")) return false;
             // Handle the entry point being a symlink
             try {
-                const realpath = path.resolve(fs.readlinkSync(arg));
+                const realpath = fs.realpathSync(arg);
                 if (realpath == launchFilePath) return false;
             } catch {
                 /* ignore errors, the arg may not be a path at all */


### PR DESCRIPTION
**Summary**
I've had trouble running `checksync` for quite a while. I had to resort to running it by passing the entrypoint file to node manually `node path/to/checksync.js`.  

The error I'd see is this:
```
(node:45761) UnhandledPromiseRejectionWarning: Error: ENOTDIR: not a directory, scandir '/Users/jeremy/.volta/tools/image/packages/checksync/bin/checksync'
(node:45761) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:45761) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

**Issues**
I haven't raised an issue for this.  I can, if you'd like. :) 

**Details**

I finally traced the error to how symlinks are resolved for unrecognized args.

The process sees a `__filename` of `/Users/jeremy/.volta/tools/image/packages/checksync/bin/checksync`. On my system, `fs.readlinkSync(__filename)` returns `../lib/node_modules/.bin/checksync`.  When `path.resolve()` resolves that path, it ends up at a path that doesn't exist on my system because it joins `process.cwd()` with the relative path passed to `path.resolve()`. 

I _think_ the fix is just to use `fs.realpathSync()` which appears to resolve to the right path on my system. 


**Screenshots**
If applicable, add screenshots to help illustrate your changes

**Review notes**
Add additional context for reviewers here. Consider what, if anything, needs particular attention paid to it.
If this is a draft, perhaps clarify what work remains and what, if anything, is ready for review.
