### PR TITLE
Add cwd arg and cwd behavior

### DIFF
--- a/.changeset/lovely-apples-cough.md
+++ b/.changeset/lovely-apples-cough.md
@@ -1,0 +1,5 @@
+---
+"checksync": minor
+---
+
+Add `--cwd` argument for specifying the working directory. Checksync looks for configuration file and resolves globs based on the current working directory, which is usually set by the process launching checksync.

--- a/.changeset/lovely-apples-cough.md
+++ b/.changeset/lovely-apples-cough.md
@@ -1,5 +1,7 @@
 ---
-"checksync": minor
+"checksync": major
 ---
 
-Add `--cwd` argument for specifying the working directory. Checksync looks for configuration file and resolves globs based on the current working directory, which is usually set by the process launching checksync.
+- The location of the configuration file is now used as the current working directory, if a configuration file is used. This means that globs are resolved relative to the configuration file, not the current working directory of the process launching checksync, which makes for a more deterministic behavior for
+folks trying to define and use their config files.
+- A `--cwd` argument has been added for specifying the working directory in cases where a configuration file is not used, or the configuration file discover needs to start in a place other than where checksync is invoked. If a configuration file is loaded, the location of that file takes precedence.

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
 
   status:
     project:
-      default: on
+      default: true
     patch:
       default: off
     changes:
@@ -14,6 +14,6 @@ coverage:
 comment:
   layout: "header, reach, diff, flags, files, footer"
   behavior: default
-  require_changes: no
-  require_base: no
-  require_head: yes
+  require_changes: false
+  require_base: false
+  require_head: true

--- a/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -66,6 +66,21 @@ Where:
                            [1m[33m.checksyncrc[39m[22m
                            [1m[33m.checksyncrc.json[39m[22m
 
+                       Paths within the config file are resolved relative to
+                       the location of the config file.
+
+    [1m[33m--cwd[39m[22m              The current working directory to use when searching
+                       for a configuration file, and resolving relative paths
+                       and globs.
+
+                       The [1m[33m--config[39m[22m path takes precedence over this
+                       argument. If there is no [1m[33m--config[39m[22m argument, this
+                       location is used to find a config file. If a config file
+                       is found, the working directory will then change to
+                       the location of that file, otherwise this argument's
+                       value is used when resolve the remainder of the given
+                       arguments.
+
     [1m[33m--dry-run,-n[39m[22m       Ignored unless supplied with [1m[33m--update-tags[39m[22m.
 
     [1m[33m--help,-h[39m[22m          Outputs this help text.

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -1,22 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Integration Tests (see __examples__ folder) should report example checksums_need_updating to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["checksums_need_updating/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/checksums_need_updating/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "checksums_need_updating/**"
+    "**/checksums_need_updating/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -26,43 +27,44 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/checksums_need_updating/b.py",
     "ROOT_DIR/__examples__/checksums_need_updating/c.jsx"
 ]
-Mismatch checksums_need_updating/a.js:4
-Looks like you changed the target content for sync-tag 'update_me' in 'checksums_need_updating/b.py:3'
+Mismatch __examples__/checksums_need_updating/a.js:4
+Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'
 Make sure you've made the parallel changes in the source file, if necessary (45678 != 249234014)
-Mismatch checksums_need_updating/a.js:5
-Looks like you changed the target content for sync-tag 'update_me' in 'checksums_need_updating/c.jsx:3'
+Mismatch __examples__/checksums_need_updating/a.js:5
+Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/c.jsx:3'
 Make sure you've made the parallel changes in the source file, if necessary (1234 != 1992689801)
-Mismatch checksums_need_updating/b.py:3
-Looks like you changed the target content for sync-tag 'update_me' in 'checksums_need_updating/a.js:4'
+Mismatch __examples__/checksums_need_updating/b.py:3
+Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:4'
 Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)
-Mismatch checksums_need_updating/c.jsx:3
-Looks like you changed the target content for sync-tag 'update_me' in 'checksums_need_updating/a.js:5'
+Mismatch __examples__/checksums_need_updating/c.jsx:3
+Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:5'
 Make sure you've made the parallel changes in the source file, if necessary (123 != 2050223083)
 
 <group 🛠  Desynchronized blocks detected. Check them and update as required before resynchronizing: >
 
-  checksync -u checksums_need_updating/a.js checksums_need_updating/b.py checksums_need_updating/c.jsx
+  checksync -u __examples__/checksums_need_updating/a.js __examples__/checksums_need_updating/b.py __examples__/checksums_need_updating/c.jsx
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example checksums_need_updating to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["checksums_need_updating/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/checksums_need_updating/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "checksums_need_updating/**"
+    "**/checksums_need_updating/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -72,45 +74,46 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/checksums_need_updating/b.py",
     "ROOT_DIR/__examples__/checksums_need_updating/c.jsx"
 ]
-Verbose  checksums_need_updating/a.js
+Verbose  __examples__/checksums_need_updating/a.js
 File has errors; skipping auto-fix
-Fix      checksums_need_updating/a.js:4
-Updated checksum for sync-tag 'update_me' referencing 'checksums_need_updating/b.py:3' from 45678 to 249234014.
-Fix      checksums_need_updating/a.js:5
-Updated checksum for sync-tag 'update_me' referencing 'checksums_need_updating/c.jsx:3' from 1234 to 1992689801.
-Verbose  checksums_need_updating/b.py
+Fix      __examples__/checksums_need_updating/a.js:4
+Updated checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/b.py:3' from 45678 to 249234014.
+Fix      __examples__/checksums_need_updating/a.js:5
+Updated checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/c.jsx:3' from 1234 to 1992689801.
+Verbose  __examples__/checksums_need_updating/b.py
 File has errors; skipping auto-fix
-Fix      checksums_need_updating/b.py:3
-Updated checksum for sync-tag 'update_me' referencing 'checksums_need_updating/a.js:4' from 4567 to 2050223083.
-Verbose  checksums_need_updating/c.jsx
+Fix      __examples__/checksums_need_updating/b.py:3
+Updated checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/a.js:4' from 4567 to 2050223083.
+Verbose  __examples__/checksums_need_updating/c.jsx
 File has errors; skipping auto-fix
-Fix      checksums_need_updating/c.jsx:3
-Updated checksum for sync-tag 'update_me' referencing 'checksums_need_updating/a.js:5' from 123 to 2050223083.
+Fix      __examples__/checksums_need_updating/c.jsx:3
+Updated checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/a.js:5' from 123 to 2050223083.
 
 <group 3 file(s) would have been fixed.
 To fix, run: >
-  checksync -u checksums_need_updating/a.js checksums_need_updating/b.py checksums_need_updating/c.jsx
+  checksync -u __examples__/checksums_need_updating/a.js __examples__/checksums_need_updating/b.py __examples__/checksums_need_updating/c.jsx
 <end_group>
 🎉  Everything is in sync!"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example checksums_need_updating to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["checksums_need_updating/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/checksums_need_updating/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "checksums_need_updating/**"
+    "**/checksums_need_updating/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -122,12 +125,12 @@ Verbose  Discovered paths: [
 ]
 {
     "version": "0.0.0",
-    "launchString": "checksync -u checksums_need_updating/a.js checksums_need_updating/b.py checksums_need_updating/c.jsx",
+    "launchString": "checksync -u __examples__/checksums_need_updating/a.js __examples__/checksums_need_updating/b.py __examples__/checksums_need_updating/c.jsx",
     "files": {
         "__examples__/checksums_need_updating/a.js": [
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'update_me' in 'checksums_need_updating/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (45678 != 249234014)",
+                "reason": "Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (45678 != 249234014)",
                 "location": {
                     "line": 3
                 },
@@ -136,12 +139,12 @@ Verbose  Discovered paths: [
                     "line": 4,
                     "text": "    // sync-start:update_me 249234014 __examples__/checksums_need_updating/b.py",
                     "declaration": "    // sync-start:update_me 45678 __examples__/checksums_need_updating/b.py",
-                    "description": "Updated checksum for sync-tag 'update_me' referencing 'checksums_need_updating/b.py:3' from 45678 to 249234014."
+                    "description": "Updated checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/b.py:3' from 45678 to 249234014."
                 }
             },
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'update_me' in 'checksums_need_updating/c.jsx:3'. Make sure you've made the parallel changes in the source file, if necessary (1234 != 1992689801)",
+                "reason": "Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/c.jsx:3'. Make sure you've made the parallel changes in the source file, if necessary (1234 != 1992689801)",
                 "location": {
                     "line": 3
                 },
@@ -150,14 +153,14 @@ Verbose  Discovered paths: [
                     "line": 5,
                     "text": "    // sync-start:update_me 1992689801 __examples__/checksums_need_updating/c.jsx",
                     "declaration": "    // sync-start:update_me 1234 __examples__/checksums_need_updating/c.jsx",
-                    "description": "Updated checksum for sync-tag 'update_me' referencing 'checksums_need_updating/c.jsx:3' from 1234 to 1992689801."
+                    "description": "Updated checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/c.jsx:3' from 1234 to 1992689801."
                 }
             }
         ],
         "__examples__/checksums_need_updating/b.py": [
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'update_me' in 'checksums_need_updating/a.js:4'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)",
+                "reason": "Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:4'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)",
                 "location": {
                     "line": 4
                 },
@@ -166,14 +169,14 @@ Verbose  Discovered paths: [
                     "line": 3,
                     "text": "# sync-start:update_me 2050223083 __examples__/checksums_need_updating/a.js",
                     "declaration": "# sync-start:update_me 4567 __examples__/checksums_need_updating/a.js",
-                    "description": "Updated checksum for sync-tag 'update_me' referencing 'checksums_need_updating/a.js:4' from 4567 to 2050223083."
+                    "description": "Updated checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/a.js:4' from 4567 to 2050223083."
                 }
             }
         ],
         "__examples__/checksums_need_updating/c.jsx": [
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'update_me' in 'checksums_need_updating/a.js:5'. Make sure you've made the parallel changes in the source file, if necessary (123 != 2050223083)",
+                "reason": "Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/a.js:5'. Make sure you've made the parallel changes in the source file, if necessary (123 != 2050223083)",
                 "location": {
                     "line": 5
                 },
@@ -182,7 +185,7 @@ Verbose  Discovered paths: [
                     "line": 3,
                     "text": "        {/* sync-start:update_me 2050223083 __examples__/checksums_need_updating/a.js */}",
                     "declaration": "        {/* sync-start:update_me 123 __examples__/checksums_need_updating/a.js */}",
-                    "description": "Updated checksum for sync-tag 'update_me' referencing 'checksums_need_updating/a.js:5' from 123 to 2050223083."
+                    "description": "Updated checksum for sync-tag 'update_me' referencing '__examples__/checksums_need_updating/a.js:5' from 123 to 2050223083."
                 }
             }
         ]
@@ -191,22 +194,23 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example content_after_start to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["content_after_start/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/content_after_start/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "content_after_start/**"
+    "**/content_after_start/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -216,51 +220,52 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/content_after_start/b.py",
     "ROOT_DIR/__examples__/content_after_start/c.js"
 ]
-Mismatch content_after_start/a.js:3
-Looks like you changed the target content for sync-tag 'content_after_start' in 'content_after_start/b.py:3'
+Mismatch __examples__/content_after_start/a.js:3
+Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/b.py:3'
 Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)
-Mismatch content_after_start/b.py:3
-Looks like you changed the target content for sync-tag 'content_after_start' in 'content_after_start/a.js:3'
+Mismatch __examples__/content_after_start/b.py:3
+Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/a.js:3'
 Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)
-Mismatch content_after_start/b.py:4
-Looks like you changed the target content for sync-tag 'content_after_start' in 'content_after_start/c.js:3'
+Mismatch __examples__/content_after_start/b.py:4
+Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/c.js:3'
 Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)
-Error    content_after_start/c.js:5
+Error    __examples__/content_after_start/c.js:5
 Sync-start for 'content_after_start' found after content started
-Mismatch content_after_start/c.js:3
-Looks like you changed the target content for sync-tag 'content_after_start' in 'content_after_start/b.py:4'
+Mismatch __examples__/content_after_start/c.js:3
+Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/b.py:4'
 Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)
-Error    content_after_start/c.js:5
-No return tag named 'content_after_start' in 'content_after_start/a.js'
+Error    __examples__/content_after_start/c.js:5
+No return tag named 'content_after_start' in '__examples__/content_after_start/a.js'
 
 <group 🛑  Desynchronized blocks detected and parsing errors were found. Fix the errors, update the blocks, then update the sync-start tags using: >
 
-  checksync -u content_after_start/a.js content_after_start/b.py content_after_start/c.js
+  checksync -u __examples__/content_after_start/a.js __examples__/content_after_start/b.py __examples__/content_after_start/c.js
 <end_group>
 
 <group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
-  content_after_start/c.js
+  __examples__/content_after_start/c.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example content_after_start to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["content_after_start/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/content_after_start/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "content_after_start/**"
+    "**/content_after_start/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -270,48 +275,49 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/content_after_start/b.py",
     "ROOT_DIR/__examples__/content_after_start/c.js"
 ]
-Verbose  content_after_start/a.js
+Verbose  __examples__/content_after_start/a.js
 File has errors; skipping auto-fix
-Fix      content_after_start/a.js:3
-Updated checksum for sync-tag 'content_after_start' referencing 'content_after_start/b.py:3' from no checksum to 249234014.
-Verbose  content_after_start/b.py
+Fix      __examples__/content_after_start/a.js:3
+Updated checksum for sync-tag 'content_after_start' referencing '__examples__/content_after_start/b.py:3' from no checksum to 249234014.
+Verbose  __examples__/content_after_start/b.py
 File has errors; skipping auto-fix
-Fix      content_after_start/b.py:3
-Updated checksum for sync-tag 'content_after_start' referencing 'content_after_start/a.js:3' from no checksum to 770446101.
-Fix      content_after_start/b.py:4
-Updated checksum for sync-tag 'content_after_start' referencing 'content_after_start/c.js:3' from no checksum to 770446101.
-Error    content_after_start/c.js:5
+Fix      __examples__/content_after_start/b.py:3
+Updated checksum for sync-tag 'content_after_start' referencing '__examples__/content_after_start/a.js:3' from no checksum to 770446101.
+Fix      __examples__/content_after_start/b.py:4
+Updated checksum for sync-tag 'content_after_start' referencing '__examples__/content_after_start/c.js:3' from no checksum to 770446101.
+Error    __examples__/content_after_start/c.js:5
 Sync-start for 'content_after_start' found after content started
-Error    content_after_start/c.js:5
-No return tag named 'content_after_start' in 'content_after_start/a.js'
+Error    __examples__/content_after_start/c.js:5
+No return tag named 'content_after_start' in '__examples__/content_after_start/a.js'
 
 <group 3 file(s) would have been fixed.
 To fix, run: >
-  checksync -u content_after_start/a.js content_after_start/b.py content_after_start/c.js
+  checksync -u __examples__/content_after_start/a.js __examples__/content_after_start/b.py __examples__/content_after_start/c.js
 <end_group>
 
 <group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
-  content_after_start/c.js
+  __examples__/content_after_start/c.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example content_after_start to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["content_after_start/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/content_after_start/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "content_after_start/**"
+    "**/content_after_start/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -324,12 +330,12 @@ Verbose  Discovered paths: [
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
-    "launchString": "checksync -u content_after_start/a.js content_after_start/b.py content_after_start/c.js",
+    "launchString": "checksync -u __examples__/content_after_start/a.js __examples__/content_after_start/b.py __examples__/content_after_start/c.js",
     "files": {
         "__examples__/content_after_start/a.js": [
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'content_after_start' in 'content_after_start/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)",
+                "reason": "Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)",
                 "location": {
                     "line": 3
                 },
@@ -338,14 +344,14 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
                     "line": 3,
                     "text": "// sync-start:content_after_start 249234014 __examples__/content_after_start/b.py",
                     "declaration": "// sync-start:content_after_start __examples__/content_after_start/b.py",
-                    "description": "Updated checksum for sync-tag 'content_after_start' referencing 'content_after_start/b.py:3' from no checksum to 249234014."
+                    "description": "Updated checksum for sync-tag 'content_after_start' referencing '__examples__/content_after_start/b.py:3' from no checksum to 249234014."
                 }
             }
         ],
         "__examples__/content_after_start/b.py": [
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'content_after_start' in 'content_after_start/a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)",
+                "reason": "Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)",
                 "location": {
                     "line": 3
                 },
@@ -354,12 +360,12 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
                     "line": 3,
                     "text": "# sync-start:content_after_start 770446101 __examples__/content_after_start/a.js",
                     "declaration": "# sync-start:content_after_start __examples__/content_after_start/a.js",
-                    "description": "Updated checksum for sync-tag 'content_after_start' referencing 'content_after_start/a.js:3' from no checksum to 770446101."
+                    "description": "Updated checksum for sync-tag 'content_after_start' referencing '__examples__/content_after_start/a.js:3' from no checksum to 770446101."
                 }
             },
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'content_after_start' in 'content_after_start/c.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)",
+                "reason": "Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/c.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)",
                 "location": {
                     "line": 3
                 },
@@ -368,7 +374,7 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
                     "line": 4,
                     "text": "# sync-start:content_after_start 770446101 __examples__/content_after_start/c.js",
                     "declaration": "# sync-start:content_after_start __examples__/content_after_start/c.js",
-                    "description": "Updated checksum for sync-tag 'content_after_start' referencing 'content_after_start/c.js:3' from no checksum to 770446101."
+                    "description": "Updated checksum for sync-tag 'content_after_start' referencing '__examples__/content_after_start/c.js:3' from no checksum to 770446101."
                 }
             }
         ],
@@ -382,7 +388,7 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
             },
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'content_after_start' in 'content_after_start/b.py:4'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)",
+                "reason": "Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/b.py:4'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)",
                 "location": {
                     "line": 4
                 },
@@ -391,11 +397,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
                     "line": 3,
                     "text": "// sync-start:content_after_start 249234014 __examples__/content_after_start/b.py",
                     "declaration": "// sync-start:content_after_start __examples__/content_after_start/b.py",
-                    "description": "Updated checksum for sync-tag 'content_after_start' referencing 'content_after_start/b.py:4' from no checksum to 249234014."
+                    "description": "Updated checksum for sync-tag 'content_after_start' referencing '__examples__/content_after_start/b.py:4' from no checksum to 249234014."
                 }
             },
             {
-                "reason": "No return tag named 'content_after_start' in 'content_after_start/a.js'",
+                "reason": "No return tag named 'content_after_start' in '__examples__/content_after_start/a.js'",
                 "code": "no-return-tag",
                 "location": {
                     "line": 5
@@ -407,22 +413,23 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example correct_checksums to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["correct_checksums/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/correct_checksums/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "correct_checksums/**"
+    "**/correct_checksums/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -436,23 +443,24 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example correct_checksums to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["correct_checksums/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/correct_checksums/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "correct_checksums/**"
+    "**/correct_checksums/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -466,22 +474,23 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example correct_checksums to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["correct_checksums/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/correct_checksums/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "correct_checksums/**"
+    "**/correct_checksums/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -499,22 +508,23 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example directory_target to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["directory_target/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/directory_target/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "directory_target/**"
+    "**/directory_target/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -523,34 +533,35 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/directory_target/a_directory/somefile.js",
     "ROOT_DIR/__examples__/directory_target/example.js"
 ]
-Error    directory_target/example.js:3
+Error    __examples__/directory_target/example.js:3
 Sync-start for 'directory_target' points to '__examples__/directory_target/a_directory', which does not exist or is a directory
-Error    directory_target/example.js:3
-No return tag named 'directory_target' in 'directory_target/a_directory'
+Error    __examples__/directory_target/example.js:3
+No return tag named 'directory_target' in '__examples__/directory_target/a_directory'
 
 <group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
-  directory_target/example.js
+  __examples__/directory_target/example.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example directory_target to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["directory_target/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/directory_target/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "directory_target/**"
+    "**/directory_target/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -559,33 +570,34 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/directory_target/a_directory/somefile.js",
     "ROOT_DIR/__examples__/directory_target/example.js"
 ]
-Error    directory_target/example.js:3
+Error    __examples__/directory_target/example.js:3
 Sync-start for 'directory_target' points to '__examples__/directory_target/a_directory', which does not exist or is a directory
-Error    directory_target/example.js:3
-No return tag named 'directory_target' in 'directory_target/a_directory'
+Error    __examples__/directory_target/example.js:3
+No return tag named 'directory_target' in '__examples__/directory_target/a_directory'
 
 <group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
-  directory_target/example.js
+  __examples__/directory_target/example.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example directory_target to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["directory_target/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/directory_target/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "directory_target/**"
+    "**/directory_target/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -608,7 +620,7 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
                 "code": "file-does-not-exist"
             },
             {
-                "reason": "No return tag named 'directory_target' in 'directory_target/a_directory'",
+                "reason": "No return tag named 'directory_target' in '__examples__/directory_target/a_directory'",
                 "code": "no-return-tag",
                 "location": {
                     "line": 3
@@ -620,22 +632,23 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example duplicate-target to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["duplicate-target/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/duplicate-target/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "duplicate-target/**"
+    "**/duplicate-target/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -644,42 +657,43 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/duplicate-target/a.js",
     "ROOT_DIR/__examples__/duplicate-target/b.py"
 ]
-Warning  duplicate-target/a.js:5
+Warning  __examples__/duplicate-target/a.js:5
 Duplicate target for sync-tag 'update_me'
-Mismatch duplicate-target/a.js:4
-Looks like you changed the target content for sync-tag 'update_me' in 'duplicate-target/b.py:3'
+Mismatch __examples__/duplicate-target/a.js:4
+Looks like you changed the target content for sync-tag 'update_me' in '__examples__/duplicate-target/b.py:3'
 Make sure you've made the parallel changes in the source file, if necessary (12352 != 249234014)
-Mismatch duplicate-target/a.js:5
-Looks like you changed the target content for sync-tag 'update_me' in 'duplicate-target/b.py:3'
+Mismatch __examples__/duplicate-target/a.js:5
+Looks like you changed the target content for sync-tag 'update_me' in '__examples__/duplicate-target/b.py:3'
 Make sure you've made the parallel changes in the source file, if necessary (12345 != 249234014)
-Mismatch duplicate-target/b.py:3
-Looks like you changed the target content for sync-tag 'update_me' in 'duplicate-target/a.js:4'
+Mismatch __examples__/duplicate-target/b.py:3
+Looks like you changed the target content for sync-tag 'update_me' in '__examples__/duplicate-target/a.js:4'
 Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)
 
 <group 🛠  Desynchronized blocks detected. Check them and update as required before resynchronizing: >
 
-  checksync -u duplicate-target/a.js duplicate-target/b.py
+  checksync -u __examples__/duplicate-target/a.js __examples__/duplicate-target/b.py
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example duplicate-target to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["duplicate-target/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/duplicate-target/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "duplicate-target/**"
+    "**/duplicate-target/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -688,41 +702,42 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/duplicate-target/a.js",
     "ROOT_DIR/__examples__/duplicate-target/b.py"
 ]
-Verbose  duplicate-target/a.js
+Verbose  __examples__/duplicate-target/a.js
 File has errors; skipping auto-fix
-Fix      duplicate-target/a.js:4
-Updated checksum for sync-tag 'update_me' referencing 'duplicate-target/b.py:3' from 12352 to 249234014.
-Fix      duplicate-target/a.js:5
+Fix      __examples__/duplicate-target/a.js:4
+Updated checksum for sync-tag 'update_me' referencing '__examples__/duplicate-target/b.py:3' from 12352 to 249234014.
+Fix      __examples__/duplicate-target/a.js:5
 Removed duplicate target for sync-tag 'update_me'
-Verbose  duplicate-target/b.py
+Verbose  __examples__/duplicate-target/b.py
 File has errors; skipping auto-fix
-Fix      duplicate-target/b.py:3
-Updated checksum for sync-tag 'update_me' referencing 'duplicate-target/a.js:4' from 4567 to 2050223083.
+Fix      __examples__/duplicate-target/b.py:3
+Updated checksum for sync-tag 'update_me' referencing '__examples__/duplicate-target/a.js:4' from 4567 to 2050223083.
 
 <group 2 file(s) would have been fixed.
 To fix, run: >
-  checksync -u duplicate-target/a.js duplicate-target/b.py
+  checksync -u __examples__/duplicate-target/a.js __examples__/duplicate-target/b.py
 <end_group>
 🎉  Everything is in sync!"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example duplicate-target to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["duplicate-target/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/duplicate-target/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "duplicate-target/**"
+    "**/duplicate-target/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -733,7 +748,7 @@ Verbose  Discovered paths: [
 ]
 {
     "version": "0.0.0",
-    "launchString": "checksync -u duplicate-target/a.js duplicate-target/b.py",
+    "launchString": "checksync -u __examples__/duplicate-target/a.js __examples__/duplicate-target/b.py",
     "files": {
         "__examples__/duplicate-target/a.js": [
             {
@@ -751,7 +766,7 @@ Verbose  Discovered paths: [
             },
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'update_me' in 'duplicate-target/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (12352 != 249234014)",
+                "reason": "Looks like you changed the target content for sync-tag 'update_me' in '__examples__/duplicate-target/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (12352 != 249234014)",
                 "location": {
                     "line": 3
                 },
@@ -760,12 +775,12 @@ Verbose  Discovered paths: [
                     "line": 4,
                     "text": "    // sync-start:update_me 249234014 __examples__/duplicate-target/b.py",
                     "declaration": "    // sync-start:update_me 12352 __examples__/duplicate-target/b.py",
-                    "description": "Updated checksum for sync-tag 'update_me' referencing 'duplicate-target/b.py:3' from 12352 to 249234014."
+                    "description": "Updated checksum for sync-tag 'update_me' referencing '__examples__/duplicate-target/b.py:3' from 12352 to 249234014."
                 }
             },
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'update_me' in 'duplicate-target/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (12345 != 249234014)",
+                "reason": "Looks like you changed the target content for sync-tag 'update_me' in '__examples__/duplicate-target/b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (12345 != 249234014)",
                 "location": {
                     "line": 3
                 },
@@ -774,14 +789,14 @@ Verbose  Discovered paths: [
                     "line": 5,
                     "text": "    // sync-start:update_me 249234014 __examples__/duplicate-target/b.py",
                     "declaration": "    // sync-start:update_me 12345 __examples__/duplicate-target/b.py",
-                    "description": "Updated checksum for sync-tag 'update_me' referencing 'duplicate-target/b.py:3' from 12345 to 249234014."
+                    "description": "Updated checksum for sync-tag 'update_me' referencing '__examples__/duplicate-target/b.py:3' from 12345 to 249234014."
                 }
             }
         ],
         "__examples__/duplicate-target/b.py": [
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'update_me' in 'duplicate-target/a.js:4'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)",
+                "reason": "Looks like you changed the target content for sync-tag 'update_me' in '__examples__/duplicate-target/a.js:4'. Make sure you've made the parallel changes in the source file, if necessary (4567 != 2050223083)",
                 "location": {
                     "line": 4
                 },
@@ -790,7 +805,7 @@ Verbose  Discovered paths: [
                     "line": 3,
                     "text": "# sync-start:update_me 2050223083 __examples__/duplicate-target/a.js",
                     "declaration": "# sync-start:update_me 4567 __examples__/duplicate-target/a.js",
-                    "description": "Updated checksum for sync-tag 'update_me' referencing 'duplicate-target/a.js:4' from 4567 to 2050223083."
+                    "description": "Updated checksum for sync-tag 'update_me' referencing '__examples__/duplicate-target/a.js:4' from 4567 to 2050223083."
                 }
             }
         ]
@@ -799,22 +814,23 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example end_with_no_start to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["end_with_no_start/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/end_with_no_start/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "end_with_no_start/**"
+    "**/end_with_no_start/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -822,32 +838,33 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/end_with_no_start/example.js"
 ]
-Error    end_with_no_start/example.js:5
+Error    __examples__/end_with_no_start/example.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
 <group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
-  end_with_no_start/example.js
+  __examples__/end_with_no_start/example.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example end_with_no_start to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["end_with_no_start/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/end_with_no_start/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "end_with_no_start/**"
+    "**/end_with_no_start/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -855,31 +872,32 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/end_with_no_start/example.js"
 ]
-Error    end_with_no_start/example.js:5
+Error    __examples__/end_with_no_start/example.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
 <group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
-  end_with_no_start/example.js
+  __examples__/end_with_no_start/example.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example end_with_no_start to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["end_with_no_start/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/end_with_no_start/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "end_with_no_start/**"
+    "**/end_with_no_start/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -906,22 +924,23 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example excluded to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["excluded/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/excluded/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "excluded/**"
+    "**/excluded/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -931,23 +950,24 @@ Error    No matching files"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example excluded to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["excluded/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/excluded/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "excluded/**"
+    "**/excluded/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -957,22 +977,23 @@ Error    No matching files"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example excluded to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["excluded/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/excluded/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "excluded/**"
+    "**/excluded/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -982,112 +1003,115 @@ Error    No matching files"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example ignore_files_at_different_depths to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["ignore_files_at_different_depths/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/ignore_files_at_different_depths/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "ignore_files_at_different_depths/**"
+    "**/ignore_files_at_different_depths/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
 ]
-Verbose  IGNORED  : ignore_files_at_different_depths/ignore-file.txt by ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/ignorethesewhennotinsome/bad-sync-tags-never-parsed.js by ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/alsoignorethis.txt by ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/ignore-file.txt by ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/ignore-file.txt by ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by ignore_files_at_different_depths/ignore-file.txt
-Verbose  UNIGNORED: ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by ignore_files_at_different_depths/some/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/ignore-file.txt by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/ignorethesewhennotinsome/bad-sync-tags-never-parsed.js by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/alsoignorethis.txt by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignore-file.txt by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignore-file.txt by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  UNIGNORED: __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js"
 ]
-Error    ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js:5
+Error    __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
 <group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
-  ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js
+  __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example ignore_files_at_different_depths to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["ignore_files_at_different_depths/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/ignore_files_at_different_depths/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "ignore_files_at_different_depths/**"
+    "**/ignore_files_at_different_depths/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
 ]
-Verbose  IGNORED  : ignore_files_at_different_depths/ignore-file.txt by ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/ignorethesewhennotinsome/bad-sync-tags-never-parsed.js by ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/alsoignorethis.txt by ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/ignore-file.txt by ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/ignore-file.txt by ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by ignore_files_at_different_depths/ignore-file.txt
-Verbose  UNIGNORED: ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by ignore_files_at_different_depths/some/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/ignore-file.txt by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/ignorethesewhennotinsome/bad-sync-tags-never-parsed.js by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/alsoignorethis.txt by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignore-file.txt by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignore-file.txt by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  UNIGNORED: __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js"
 ]
-Error    ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js:5
+Error    __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
 <group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
-  ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js
+  __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example ignore_files_at_different_depths to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["ignore_files_at_different_depths/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/ignore_files_at_different_depths/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "ignore_files_at_different_depths/**"
+    "**/ignore_files_at_different_depths/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
 ]
-Verbose  IGNORED  : ignore_files_at_different_depths/ignore-file.txt by ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/ignorethesewhennotinsome/bad-sync-tags-never-parsed.js by ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/alsoignorethis.txt by ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/ignore-file.txt by ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/ignore-file.txt by ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  IGNORED  : ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by ignore_files_at_different_depths/ignore-file.txt
-Verbose  UNIGNORED: ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by ignore_files_at_different_depths/some/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/ignore-file.txt by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/ignorethesewhennotinsome/bad-sync-tags-never-parsed.js by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/alsoignorethis.txt by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignore-file.txt by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignore-file.txt by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
+Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by __examples__/ignore_files_at_different_depths/ignore-file.txt
+Verbose  UNIGNORED: __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js"
 ]
@@ -1110,22 +1134,23 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_end to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["malformed_end/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/malformed_end/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "malformed_end/**"
+    "**/malformed_end/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1134,39 +1159,40 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/malformed_end/malformed_badid.js",
     "ROOT_DIR/__examples__/malformed_end/malformed_noid.js"
 ]
-Error    malformed_end/malformed_badid.js:7
+Error    __examples__/malformed_end/malformed_badid.js:7
 Malformed sync-end: format should be 'sync-end:<label>'
-Error    malformed_end/malformed_badid.js:4
+Error    __examples__/malformed_end/malformed_badid.js:4
 Sync-start 'tagid' has no corresponding sync-end
-Error    malformed_end/malformed_noid.js:7
+Error    __examples__/malformed_end/malformed_noid.js:7
 Malformed sync-end: format should be 'sync-end:<label>'
-Error    malformed_end/malformed_noid.js:4
+Error    __examples__/malformed_end/malformed_noid.js:4
 Sync-start 'tagid' has no corresponding sync-end
 
 <group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
-  malformed_end/malformed_badid.js
-malformed_end/malformed_noid.js
+  __examples__/malformed_end/malformed_badid.js
+__examples__/malformed_end/malformed_noid.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_end to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["malformed_end/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/malformed_end/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "malformed_end/**"
+    "**/malformed_end/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1175,38 +1201,39 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/malformed_end/malformed_badid.js",
     "ROOT_DIR/__examples__/malformed_end/malformed_noid.js"
 ]
-Error    malformed_end/malformed_badid.js:7
+Error    __examples__/malformed_end/malformed_badid.js:7
 Malformed sync-end: format should be 'sync-end:<label>'
-Error    malformed_end/malformed_badid.js:4
+Error    __examples__/malformed_end/malformed_badid.js:4
 Sync-start 'tagid' has no corresponding sync-end
-Error    malformed_end/malformed_noid.js:7
+Error    __examples__/malformed_end/malformed_noid.js:7
 Malformed sync-end: format should be 'sync-end:<label>'
-Error    malformed_end/malformed_noid.js:4
+Error    __examples__/malformed_end/malformed_noid.js:4
 Sync-start 'tagid' has no corresponding sync-end
 
 <group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
-  malformed_end/malformed_badid.js
-malformed_end/malformed_noid.js
+  __examples__/malformed_end/malformed_badid.js
+__examples__/malformed_end/malformed_noid.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_end to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["malformed_end/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/malformed_end/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "malformed_end/**"
+    "**/malformed_end/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1257,22 +1284,23 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_start to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["malformed_start/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/malformed_start/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "malformed_start/**"
+    "**/malformed_start/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1282,44 +1310,45 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/malformed_start/malformed_badid.js",
     "ROOT_DIR/__examples__/malformed_start/malformed_onlytagid.js"
 ]
-Error    malformed_start/malformed_badchecksum.js:4
+Error    __examples__/malformed_start/malformed_badchecksum.js:4
 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
-Error    malformed_start/malformed_badchecksum.js:7
+Error    __examples__/malformed_start/malformed_badchecksum.js:7
 Sync-end for 'tagid' found, but there was no corresponding sync-start
-Error    malformed_start/malformed_badid.js:4
+Error    __examples__/malformed_start/malformed_badid.js:4
 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
-Error    malformed_start/malformed_badid.js:7
+Error    __examples__/malformed_start/malformed_badid.js:7
 Sync-end for 'tagid' found, but there was no corresponding sync-start
-Error    malformed_start/malformed_onlytagid.js:4
+Error    __examples__/malformed_start/malformed_onlytagid.js:4
 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
-Error    malformed_start/malformed_onlytagid.js:7
+Error    __examples__/malformed_start/malformed_onlytagid.js:7
 Sync-end for 'tagid' found, but there was no corresponding sync-start
 
 <group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
-  malformed_start/malformed_badchecksum.js
-malformed_start/malformed_badid.js
-malformed_start/malformed_onlytagid.js
+  __examples__/malformed_start/malformed_badchecksum.js
+__examples__/malformed_start/malformed_badid.js
+__examples__/malformed_start/malformed_onlytagid.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_start to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["malformed_start/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/malformed_start/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "malformed_start/**"
+    "**/malformed_start/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1329,43 +1358,44 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/malformed_start/malformed_badid.js",
     "ROOT_DIR/__examples__/malformed_start/malformed_onlytagid.js"
 ]
-Error    malformed_start/malformed_badchecksum.js:4
+Error    __examples__/malformed_start/malformed_badchecksum.js:4
 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
-Error    malformed_start/malformed_badchecksum.js:7
+Error    __examples__/malformed_start/malformed_badchecksum.js:7
 Sync-end for 'tagid' found, but there was no corresponding sync-start
-Error    malformed_start/malformed_badid.js:4
+Error    __examples__/malformed_start/malformed_badid.js:4
 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
-Error    malformed_start/malformed_badid.js:7
+Error    __examples__/malformed_start/malformed_badid.js:7
 Sync-end for 'tagid' found, but there was no corresponding sync-start
-Error    malformed_start/malformed_onlytagid.js:4
+Error    __examples__/malformed_start/malformed_onlytagid.js:4
 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
-Error    malformed_start/malformed_onlytagid.js:7
+Error    __examples__/malformed_start/malformed_onlytagid.js:7
 Sync-end for 'tagid' found, but there was no corresponding sync-start
 
 <group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
-  malformed_start/malformed_badchecksum.js
-malformed_start/malformed_badid.js
-malformed_start/malformed_onlytagid.js
+  __examples__/malformed_start/malformed_badchecksum.js
+__examples__/malformed_start/malformed_badid.js
+__examples__/malformed_start/malformed_onlytagid.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_start to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["malformed_start/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/malformed_start/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "malformed_start/**"
+    "**/malformed_start/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1433,22 +1463,23 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example missing_target to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["missing_target/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/missing_target/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "missing_target/**"
+    "**/missing_target/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1456,34 +1487,35 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/missing_target/example.js"
 ]
-Error    missing_target/example.js:3
+Error    __examples__/missing_target/example.js:3
 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
-Error    missing_target/example.js:3
-No return tag named 'missing_target' in 'missing_target/missing_target.py'
+Error    __examples__/missing_target/example.js:3
+No return tag named 'missing_target' in '__examples__/missing_target/missing_target.py'
 
 <group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
-  missing_target/example.js
+  __examples__/missing_target/example.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example missing_target to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["missing_target/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/missing_target/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "missing_target/**"
+    "**/missing_target/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1491,33 +1523,34 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/missing_target/example.js"
 ]
-Error    missing_target/example.js:3
+Error    __examples__/missing_target/example.js:3
 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
-Error    missing_target/example.js:3
-No return tag named 'missing_target' in 'missing_target/missing_target.py'
+Error    __examples__/missing_target/example.js:3
+No return tag named 'missing_target' in '__examples__/missing_target/missing_target.py'
 
 <group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
-  missing_target/example.js
+  __examples__/missing_target/example.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example missing_target to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["missing_target/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/missing_target/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "missing_target/**"
+    "**/missing_target/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1539,7 +1572,7 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
                 "code": "file-does-not-exist"
             },
             {
-                "reason": "No return tag named 'missing_target' in 'missing_target/missing_target.py'",
+                "reason": "No return tag named 'missing_target' in '__examples__/missing_target/missing_target.py'",
                 "code": "no-return-tag",
                 "location": {
                     "line": 3
@@ -1551,22 +1584,23 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_back_reference to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["no_back_reference/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/no_back_reference/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "no_back_reference/**"
+    "**/no_back_reference/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1575,32 +1609,33 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/no_back_reference/file1.js",
     "ROOT_DIR/__examples__/no_back_reference/file2.js"
 ]
-Error    no_back_reference/file1.js:1
-No return tag named 'markerID' in 'no_back_reference/file2.js'
+Error    __examples__/no_back_reference/file1.js:1
+No return tag named 'markerID' in '__examples__/no_back_reference/file2.js'
 
 <group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
-  no_back_reference/file1.js
+  __examples__/no_back_reference/file1.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_back_reference to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["no_back_reference/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/no_back_reference/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "no_back_reference/**"
+    "**/no_back_reference/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1609,31 +1644,32 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/no_back_reference/file1.js",
     "ROOT_DIR/__examples__/no_back_reference/file2.js"
 ]
-Error    no_back_reference/file1.js:1
-No return tag named 'markerID' in 'no_back_reference/file2.js'
+Error    __examples__/no_back_reference/file1.js:1
+No return tag named 'markerID' in '__examples__/no_back_reference/file2.js'
 
 <group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
-  no_back_reference/file1.js
+  __examples__/no_back_reference/file1.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_back_reference to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["no_back_reference/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/no_back_reference/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "no_back_reference/**"
+    "**/no_back_reference/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1649,7 +1685,7 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
     "files": {
         "__examples__/no_back_reference/file1.js": [
             {
-                "reason": "No return tag named 'markerID' in 'no_back_reference/file2.js'",
+                "reason": "No return tag named 'markerID' in '__examples__/no_back_reference/file2.js'",
                 "code": "no-return-tag",
                 "location": {
                     "line": 1
@@ -1661,22 +1697,23 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_checksums to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["no_checksums/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/no_checksums/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "no_checksums/**"
+    "**/no_checksums/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1685,37 +1722,38 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/no_checksums/example_one-a.js",
     "ROOT_DIR/__examples__/no_checksums/example_one-b.py"
 ]
-Mismatch no_checksums/example_one-a.js:3
-Looks like you changed the target content for sync-tag 'example_one' in 'no_checksums/example_one-b.py:3'
+Mismatch __examples__/no_checksums/example_one-a.js:3
+Looks like you changed the target content for sync-tag 'example_one' in '__examples__/no_checksums/example_one-b.py:3'
 Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)
-Mismatch no_checksums/example_one-b.py:3
-Looks like you changed the target content for sync-tag 'example_one' in 'no_checksums/example_one-a.js:3'
+Mismatch __examples__/no_checksums/example_one-b.py:3
+Looks like you changed the target content for sync-tag 'example_one' in '__examples__/no_checksums/example_one-a.js:3'
 Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)
 
 <group 🛠  Desynchronized blocks detected. Check them and update as required before resynchronizing: >
 
-  checksync -u no_checksums/example_one-a.js no_checksums/example_one-b.py
+  checksync -u __examples__/no_checksums/example_one-a.js __examples__/no_checksums/example_one-b.py
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_checksums to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["no_checksums/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/no_checksums/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "no_checksums/**"
+    "**/no_checksums/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1724,39 +1762,40 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/no_checksums/example_one-a.js",
     "ROOT_DIR/__examples__/no_checksums/example_one-b.py"
 ]
-Verbose  no_checksums/example_one-a.js
+Verbose  __examples__/no_checksums/example_one-a.js
 File has errors; skipping auto-fix
-Fix      no_checksums/example_one-a.js:3
-Updated checksum for sync-tag 'example_one' referencing 'no_checksums/example_one-b.py:3' from no checksum to 249234014.
-Verbose  no_checksums/example_one-b.py
+Fix      __examples__/no_checksums/example_one-a.js:3
+Updated checksum for sync-tag 'example_one' referencing '__examples__/no_checksums/example_one-b.py:3' from no checksum to 249234014.
+Verbose  __examples__/no_checksums/example_one-b.py
 File has errors; skipping auto-fix
-Fix      no_checksums/example_one-b.py:3
-Updated checksum for sync-tag 'example_one' referencing 'no_checksums/example_one-a.js:3' from no checksum to 770446101.
+Fix      __examples__/no_checksums/example_one-b.py:3
+Updated checksum for sync-tag 'example_one' referencing '__examples__/no_checksums/example_one-a.js:3' from no checksum to 770446101.
 
 <group 2 file(s) would have been fixed.
 To fix, run: >
-  checksync -u no_checksums/example_one-a.js no_checksums/example_one-b.py
+  checksync -u __examples__/no_checksums/example_one-a.js __examples__/no_checksums/example_one-b.py
 <end_group>
 🎉  Everything is in sync!"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_checksums to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["no_checksums/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/no_checksums/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "no_checksums/**"
+    "**/no_checksums/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1767,12 +1806,12 @@ Verbose  Discovered paths: [
 ]
 {
     "version": "0.0.0",
-    "launchString": "checksync -u no_checksums/example_one-a.js no_checksums/example_one-b.py",
+    "launchString": "checksync -u __examples__/no_checksums/example_one-a.js __examples__/no_checksums/example_one-b.py",
     "files": {
         "__examples__/no_checksums/example_one-a.js": [
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'example_one' in 'no_checksums/example_one-b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)",
+                "reason": "Looks like you changed the target content for sync-tag 'example_one' in '__examples__/no_checksums/example_one-b.py:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 249234014)",
                 "location": {
                     "line": 3
                 },
@@ -1781,14 +1820,14 @@ Verbose  Discovered paths: [
                     "line": 3,
                     "text": "// sync-start:example_one 249234014 __examples__/no_checksums/example_one-b.py",
                     "declaration": "// sync-start:example_one __examples__/no_checksums/example_one-b.py",
-                    "description": "Updated checksum for sync-tag 'example_one' referencing 'no_checksums/example_one-b.py:3' from no checksum to 249234014."
+                    "description": "Updated checksum for sync-tag 'example_one' referencing '__examples__/no_checksums/example_one-b.py:3' from no checksum to 249234014."
                 }
             }
         ],
         "__examples__/no_checksums/example_one-b.py": [
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'example_one' in 'no_checksums/example_one-a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)",
+                "reason": "Looks like you changed the target content for sync-tag 'example_one' in '__examples__/no_checksums/example_one-a.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)",
                 "location": {
                     "line": 3
                 },
@@ -1797,7 +1836,7 @@ Verbose  Discovered paths: [
                     "line": 3,
                     "text": "# sync-start:example_one 770446101 __examples__/no_checksums/example_one-a.js",
                     "declaration": "# sync-start:example_one __examples__/no_checksums/example_one-a.js",
-                    "description": "Updated checksum for sync-tag 'example_one' referencing 'no_checksums/example_one-a.js:3' from no checksum to 770446101."
+                    "description": "Updated checksum for sync-tag 'example_one' referencing '__examples__/no_checksums/example_one-a.js:3' from no checksum to 770446101."
                 }
             }
         ]
@@ -1806,22 +1845,23 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_self_reference to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["no_self_reference/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/no_self_reference/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "no_self_reference/**"
+    "**/no_self_reference/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1829,40 +1869,41 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/no_self_reference/example.js"
 ]
-Error    no_self_reference/example.js:3
+Error    __examples__/no_self_reference/example.js:3
 Sync-tag 'example_three' cannot target itself
-Mismatch no_self_reference/example.js:3
-Looks like you changed the target content for sync-tag 'example_three' in 'no_self_reference/example.js:3'
+Mismatch __examples__/no_self_reference/example.js:3
+Looks like you changed the target content for sync-tag 'example_three' in '__examples__/no_self_reference/example.js:3'
 Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)
 
 <group 🛑  Desynchronized blocks detected and parsing errors were found. Fix the errors, update the blocks, then update the sync-start tags using: >
 
-  checksync -u no_self_reference/example.js
+  checksync -u __examples__/no_self_reference/example.js
 <end_group>
 
 <group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
-  no_self_reference/example.js
+  __examples__/no_self_reference/example.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_self_reference to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["no_self_reference/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/no_self_reference/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "no_self_reference/**"
+    "**/no_self_reference/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1870,36 +1911,37 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/no_self_reference/example.js"
 ]
-Error    no_self_reference/example.js:3
+Error    __examples__/no_self_reference/example.js:3
 Sync-tag 'example_three' cannot target itself
 
 <group 1 file(s) would have been fixed.
 To fix, run: >
-  checksync -u no_self_reference/example.js
+  checksync -u __examples__/no_self_reference/example.js
 <end_group>
 
 <group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
-  no_self_reference/example.js
+  __examples__/no_self_reference/example.js
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_self_reference to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["no_self_reference/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/no_self_reference/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "no_self_reference/**"
+    "**/no_self_reference/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1910,7 +1952,7 @@ Verbose  Discovered paths: [
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
-    "launchString": "checksync -u no_self_reference/example.js",
+    "launchString": "checksync -u __examples__/no_self_reference/example.js",
     "files": {
         "__examples__/no_self_reference/example.js": [
             {
@@ -1922,7 +1964,7 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
             },
             {
                 "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'example_three' in 'no_self_reference/example.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)",
+                "reason": "Looks like you changed the target content for sync-tag 'example_three' in '__examples__/no_self_reference/example.js:3'. Make sure you've made the parallel changes in the source file, if necessary (No checksum != 770446101)",
                 "location": {
                     "line": 3
                 },
@@ -1931,7 +1973,7 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
                     "line": 3,
                     "text": "// sync-start:example_three 770446101 __examples__/no_self_reference/example.js",
                     "declaration": "// sync-start:example_three __examples__/no_self_reference/example.js",
-                    "description": "Updated checksum for sync-tag 'example_three' referencing 'no_self_reference/example.js:3' from no checksum to 770446101."
+                    "description": "Updated checksum for sync-tag 'example_three' referencing '__examples__/no_self_reference/example.js:3' from no checksum to 770446101."
                 }
             }
         ]
@@ -1940,22 +1982,23 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example unterminated_marker to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["unterminated_marker/**"]}
+"Verbose  Options from arguments: {"includeGlobs":["**/unterminated_marker/**"]}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "unterminated_marker/**"
+    "**/unterminated_marker/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -1964,35 +2007,36 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/unterminated_marker/example_two-a.js",
     "ROOT_DIR/__examples__/unterminated_marker/example_two-b.py"
 ]
-Error    unterminated_marker/example_two-a.js:3
-No return tag named 'example_two' in 'unterminated_marker/example_two-b.py'
-Error    unterminated_marker/example_two-b.py:3
+Error    __examples__/unterminated_marker/example_two-a.js:3
+No return tag named 'example_two' in '__examples__/unterminated_marker/example_two-b.py'
+Error    __examples__/unterminated_marker/example_two-b.py:3
 Sync-start 'example_two' has no corresponding sync-end
 
 <group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
-  unterminated_marker/example_two-a.js
-unterminated_marker/example_two-b.py
+  __examples__/unterminated_marker/example_two-a.js
+__examples__/unterminated_marker/example_two-b.py
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example unterminated_marker to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["unterminated_marker/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/unterminated_marker/**"],"autoFix":true,"dryRun":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "unterminated_marker/**"
+    "**/unterminated_marker/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -2001,34 +2045,35 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/unterminated_marker/example_two-a.js",
     "ROOT_DIR/__examples__/unterminated_marker/example_two-b.py"
 ]
-Error    unterminated_marker/example_two-a.js:3
-No return tag named 'example_two' in 'unterminated_marker/example_two-b.py'
-Error    unterminated_marker/example_two-b.py:3
+Error    __examples__/unterminated_marker/example_two-a.js:3
+No return tag named 'example_two' in '__examples__/unterminated_marker/example_two-b.py'
+Error    __examples__/unterminated_marker/example_two-b.py:3
 Sync-start 'example_two' has no corresponding sync-end
 
 <group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
-  unterminated_marker/example_two-a.js
-unterminated_marker/example_two-b.py
+  __examples__/unterminated_marker/example_two-a.js
+__examples__/unterminated_marker/example_two-b.py
 <end_group>"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example unterminated_marker to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["unterminated_marker/**"],"json":true}
+"Verbose  Options from arguments: {"includeGlobs":["**/unterminated_marker/**"],"json":true}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
 Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
 ]
 Verbose  Include globs: [
-    "unterminated_marker/**"
+    "**/unterminated_marker/**"
 ]
 Verbose  Exclude globs: [
     "**/excluded/**"
@@ -2044,7 +2089,7 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
     "files": {
         "__examples__/unterminated_marker/example_two-a.js": [
             {
-                "reason": "No return tag named 'example_two' in 'unterminated_marker/example_two-b.py'",
+                "reason": "No return tag named 'example_two' in '__examples__/unterminated_marker/example_two-b.py'",
                 "code": "no-return-tag",
                 "location": {
                     "line": 3

--- a/src/__tests__/check-sync.test.ts
+++ b/src/__tests__/check-sync.test.ts
@@ -4,7 +4,7 @@ import * as ProcessCache from "../process-cache";
 import Logger from "../logger";
 
 import checkSync from "../check-sync";
-import ExitCodes from "../exit-codes";
+import {ExitCode} from "../exit-codes";
 
 import {Options} from "../types";
 
@@ -110,16 +110,14 @@ describe("#checkSync", () => {
         const result = await checkSync(options, NullLogger);
 
         // Assert
-        expect(result).toBe(ExitCodes.NO_FILES);
+        expect(result).toBe(ExitCode.NO_FILES);
     });
 
     it("should build a marker cache from the files", async () => {
         // Arrange
         const NullLogger = new Logger();
         jest.spyOn(GetFiles, "default").mockResolvedValue(["filea", "fileb"]);
-        jest.spyOn(ProcessCache, "default").mockResolvedValue(
-            ExitCodes.SUCCESS,
-        );
+        jest.spyOn(ProcessCache, "default").mockResolvedValue(ExitCode.SUCCESS);
         const getMarkersFromFilesSpy = jest
             .spyOn(GetMarkersFromFiles, "default")
             .mockResolvedValue({});
@@ -151,7 +149,7 @@ describe("#checkSync", () => {
         jest.spyOn(GetMarkersFromFiles, "default").mockResolvedValue(fakeCache);
         const ProcessCacheSpy = jest
             .spyOn(ProcessCache, "default")
-            .mockResolvedValue(ExitCodes.SUCCESS);
+            .mockResolvedValue(ExitCode.SUCCESS);
         const options: Options = {
             includeGlobs: ["glob1", "glob2"],
             excludeGlobs: [],
@@ -180,9 +178,7 @@ describe("#checkSync", () => {
         const fakeCache: Record<string, any> = {};
         jest.spyOn(GetFiles, "default").mockResolvedValue(["filea", "fileb"]);
         jest.spyOn(GetMarkersFromFiles, "default").mockResolvedValue(fakeCache);
-        jest.spyOn(ProcessCache, "default").mockResolvedValue(
-            ExitCodes.SUCCESS,
-        );
+        jest.spyOn(ProcessCache, "default").mockResolvedValue(ExitCode.SUCCESS);
 
         // Act
         const result = await checkSync(
@@ -199,6 +195,6 @@ describe("#checkSync", () => {
         );
 
         // Assert
-        expect(result).toBe(ExitCodes.SUCCESS);
+        expect(result).toBe(ExitCode.SUCCESS);
     });
 });

--- a/src/__tests__/exit.test.ts
+++ b/src/__tests__/exit.test.ts
@@ -1,0 +1,40 @@
+import exit from "../exit";
+import {ExitCode} from "../exit-codes";
+
+describe("exit", () => {
+    it("should verbose log the exit code and name", () => {
+        // Arrange
+        const log = {
+            verbose: jest.fn(),
+        } as any;
+        // @ts-expect-error process.exit is typed as never, but we don't want
+        // that here
+        jest.spyOn(process, "exit").mockImplementationOnce(() => {});
+        exit(log, ExitCode.SUCCESS);
+        const verboseLogFn = log.verbose.mock.calls[0][0];
+
+        // Act
+        const result = verboseLogFn();
+
+        // Assert
+        expect(result).toBe("Exiting with code 0: SUCCESS");
+    });
+
+    it("should exit the process with the given code", () => {
+        // Arrange
+        const log = {
+            verbose: jest.fn(),
+        } as any;
+        const exitSpy = jest
+            .spyOn(process, "exit")
+            // @ts-expect-error process.exit is typed as never, but we don't
+            // want that here
+            .mockImplementationOnce(() => {});
+
+        // Act
+        exit(log, ExitCode.SUCCESS);
+
+        // Assert
+        expect(exitSpy).toHaveBeenCalledWith(ExitCode.SUCCESS);
+    });
+});

--- a/src/__tests__/fix-file.test.ts
+++ b/src/__tests__/fix-file.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import readline from "readline";
 
-import ErrorCodes from "../error-codes";
+import {ErrorCode} from "../error-codes";
 import Logger from "../logger";
 import FileReferenceLogger from "../file-reference-logger";
 import fixFile from "../fix-file";
@@ -86,7 +86,7 @@ describe("#fixFile", () => {
         const promise = fixFile(options, "filea", NullFileLogger, {
             BROKEN_DECLARATION: [
                 {
-                    code: ErrorCodes.mismatchedChecksum,
+                    code: ErrorCode.mismatchedChecksum,
                     reason: "MISMATCHED CHECKSUMS REASON",
                     fix: {
                         type: "replace",
@@ -141,7 +141,7 @@ describe("#fixFile", () => {
         const promise = fixFile(options, "filea", NullFileLogger, {
             BROKEN_DECLARATION: [
                 {
-                    code: ErrorCodes.mismatchedChecksum,
+                    code: ErrorCode.mismatchedChecksum,
                     reason: "MISMATCHED CHECKSUMS REASON",
                     fix: {
                         type: "replace",
@@ -196,7 +196,7 @@ describe("#fixFile", () => {
         const promise = fixFile(options, "filea", NullFileLogger, {
             BROKEN_DECLARATION: [
                 {
-                    code: ErrorCodes.mismatchedChecksum,
+                    code: ErrorCode.mismatchedChecksum,
                     reason: "MISMATCHED CHECKSUMS REASON",
                     fix: {
                         type: "replace",
@@ -253,7 +253,7 @@ describe("#fixFile", () => {
         const promise = fixFile(options, "filea", NullFileLogger, {
             BROKEN_DECLARATION: [
                 {
-                    code: ErrorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     reason: "MISMATCHED CHECKSUMS REASON",
                     fix: {
                         type: "delete",
@@ -306,7 +306,7 @@ describe("#fixFile", () => {
         const promise = fixFile(options, "filea", NullFileLogger, {
             BROKEN_DECLARATION: [
                 {
-                    code: ErrorCodes.mismatchedChecksum,
+                    code: ErrorCode.mismatchedChecksum,
                     reason: "MISMATCHED CHECKSUMS REASON",
                     fix: {
                         type: "replace",
@@ -317,7 +317,7 @@ describe("#fixFile", () => {
                     },
                 },
                 {
-                    code: ErrorCodes.mismatchedChecksum,
+                    code: ErrorCode.mismatchedChecksum,
                     reason: "MISMATCHED CHECKSUMS REASON",
                     fix: {
                         type: "replace",
@@ -384,7 +384,7 @@ describe("#fixFile", () => {
         const promise = fixFile(testOptions, "filea", NullFileLogger, {
             BROKEN_DECLARATION: [
                 {
-                    code: ErrorCodes.mismatchedChecksum,
+                    code: ErrorCode.mismatchedChecksum,
                     reason: "MISMATCHED CHECKSUMS REASON",
                     fix: {
                         type: "replace",

--- a/src/__tests__/help.test.ts
+++ b/src/__tests__/help.test.ts
@@ -80,6 +80,21 @@ describe("#logHelp", () => {
                                        .checksyncrc
                                        .checksyncrc.json
 
+                                   Paths within the config file are resolved relative to
+                                   the location of the config file.
+
+                --cwd              The current working directory to use when searching
+                                   for a configuration file, and resolving relative paths
+                                   and globs.
+
+                                   The --config path takes precedence over this
+                                   argument. If there is no --config argument, this
+                                   location is used to find a config file. If a config file
+                                   is found, the working directory will then change to
+                                   the location of that file, otherwise this argument's
+                                   value is used when resolve the remainder of the given
+                                   arguments.
+
                 --dry-run,-n       Ignored unless supplied with --update-tags.
 
                 --help,-h          Outputs this help text.

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -34,7 +34,7 @@ describe("Integration Tests (see __examples__ folder)", () => {
         .filter((name) => fs.lstatSync(name).isDirectory())
         // Finally, this has to be an actual glob, or it won't work,
         // and we need our ignore files.
-        .map((name) => [name, `${name}/**`])
+        .map((name) => [name, `**/${name}/**`])
         .sort();
 
     it.each(exampleGlobs)(

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -3,7 +3,7 @@ import {runCli, checkSync, loadConfigurationFile} from "../main";
 import * as Cli from "../cli";
 import * as CheckSync from "../check-sync";
 import * as LoadConfigurationFile from "../load-configuration-file";
-import ExitCodes from "../exit-codes";
+import {ExitCode} from "../exit-codes";
 
 describe("main.js", () => {
     describe("#runCli", () => {
@@ -24,7 +24,7 @@ describe("main.js", () => {
             // Arrange
             const checkSyncSpy = jest
                 .spyOn(CheckSync, "default")
-                .mockImplementation(() => Promise.resolve(ExitCodes.SUCCESS));
+                .mockImplementation(() => Promise.resolve(ExitCode.SUCCESS));
             const logger: any = {
                 fake: "logger",
             };

--- a/src/__tests__/maybe-report-error.test.ts
+++ b/src/__tests__/maybe-report-error.test.ts
@@ -1,7 +1,7 @@
 import Logger from "../logger";
 import FileReferenceLogger from "../file-reference-logger";
 import maybeReportError from "../maybe-report-error";
-import {errorCodes} from "../error-codes";
+import {ErrorCode} from "../error-codes";
 
 describe("#maybeReportError", () => {
     it("should not report a fixable error", () => {
@@ -12,7 +12,7 @@ describe("#maybeReportError", () => {
         );
         const errorSpy = jest.spyOn(NullPositionLogger, "error");
         const error = {
-            code: errorCodes.mismatchedChecksum,
+            code: ErrorCode.mismatchedChecksum,
             reason: "test error",
             fix: {
                 type: "replace",
@@ -30,7 +30,7 @@ describe("#maybeReportError", () => {
         expect(errorSpy).not.toHaveBeenCalled();
     });
 
-    it.each(Object.values(errorCodes))(
+    it.each(Object.values(ErrorCode))(
         "should report non-fixable error %s with log.error",
         (code) => {
             // Arrange

--- a/src/__tests__/output-sink.test.ts
+++ b/src/__tests__/output-sink.test.ts
@@ -2,8 +2,8 @@ import Logger from "../logger";
 import StringLogger from "../string-logger";
 import OutputSink from "../output-sink";
 import defaultOptions from "../default-options";
-import {errorCodes} from "../error-codes";
-import ExitCodes from "../exit-codes";
+import {ErrorCode} from "../error-codes";
+import {ExitCode} from "../exit-codes";
 import * as MaybeReportError from "../maybe-report-error";
 import * as FileReferenceLogger from "../file-reference-logger";
 import * as FixFile from "../fix-file";
@@ -58,7 +58,7 @@ describe("OutputSink", () => {
             outputSink.startFile("foo.js");
             outputSink.processError({
                 reason: "REASON",
-                code: errorCodes.couldNotParse,
+                code: ErrorCode.couldNotParse,
             });
             await outputSink.endFile();
 
@@ -82,7 +82,7 @@ describe("OutputSink", () => {
             const underTest = () =>
                 outputSink.processError({
                     reason: "REASON",
-                    code: errorCodes.couldNotParse,
+                    code: ErrorCode.couldNotParse,
                 });
 
             // Assert
@@ -109,7 +109,7 @@ describe("OutputSink", () => {
                 const reportSpy = jest.spyOn(MaybeReportError, "default");
                 const errorDetails: ErrorDetails = {
                     reason: "REASON",
-                    code: errorCodes.couldNotParse,
+                    code: ErrorCode.couldNotParse,
                 };
                 outputSink.startFile("foo.js");
 
@@ -144,7 +144,7 @@ describe("OutputSink", () => {
                         const outputSink = new OutputSink(options, NullLogger);
                         const errorDetails: ErrorDetails = {
                             reason: "REASON",
-                            code: errorCodes.mismatchedChecksum,
+                            code: ErrorCode.mismatchedChecksum,
                             fix: {
                                 type: "replace",
                                 line: 1,
@@ -166,8 +166,8 @@ describe("OutputSink", () => {
                     });
 
                     it.each(
-                        Object.values(errorCodes).filter(
-                            (e) => e !== errorCodes.mismatchedChecksum,
+                        Object.values(ErrorCode).filter(
+                            (e) => e !== ErrorCode.mismatchedChecksum,
                         ),
                     )("should log %s errors with log.warn", (code) => {
                         // Arrange
@@ -211,7 +211,7 @@ describe("OutputSink", () => {
                 });
 
                 describe("options.autoFix = true", () => {
-                    it.each(Object.values(errorCodes))(
+                    it.each(Object.values(ErrorCode))(
                         "should not log %s errors with log.mismatch",
                         (code) => {
                             // Arrange
@@ -256,7 +256,7 @@ describe("OutputSink", () => {
                         },
                     );
 
-                    it.each(Object.values(errorCodes))(
+                    it.each(Object.values(ErrorCode))(
                         "should not log %s errors with log.warn",
                         (code) => {
                             // Arrange
@@ -320,7 +320,7 @@ describe("OutputSink", () => {
                 const reportSpy = jest.spyOn(MaybeReportError, "default");
                 const errorDetails: ErrorDetails = {
                     reason: "REASON",
-                    code: errorCodes.couldNotParse,
+                    code: ErrorCode.couldNotParse,
                 };
                 outputSink.startFile("foo.js");
 
@@ -331,7 +331,7 @@ describe("OutputSink", () => {
                 expect(reportSpy).not.toHaveBeenCalled();
             });
 
-            it.each(Object.values(errorCodes))(
+            it.each(Object.values(ErrorCode))(
                 "should not log %s errors with log.mismatch",
                 (code) => {
                     // Arrange
@@ -370,7 +370,7 @@ describe("OutputSink", () => {
                 },
             );
 
-            it.each(Object.values(errorCodes))(
+            it.each(Object.values(ErrorCode))(
                 "should not log %s errors with log.warn",
                 (code) => {
                     // Arrange
@@ -470,7 +470,7 @@ describe("OutputSink", () => {
             const outputSink = new OutputSink(options, NullLogger);
             const errorDetails: ErrorDetails = {
                 reason: "REASON",
-                code: errorCodes.duplicateTarget,
+                code: ErrorCode.duplicateTarget,
                 fix: {
                     type: "replace",
                     line: 1,
@@ -513,11 +513,11 @@ describe("OutputSink", () => {
             const outputSink = new OutputSink(options, NullLogger);
             const unfixableError: ErrorDetails = {
                 reason: "REASON",
-                code: errorCodes.couldNotParse,
+                code: ErrorCode.couldNotParse,
             };
             const fixableError: ErrorDetails = {
                 reason: "REASON",
-                code: errorCodes.duplicateTarget,
+                code: ErrorCode.duplicateTarget,
                 fix: {
                     type: "replace",
                     line: 1,
@@ -555,7 +555,7 @@ describe("OutputSink", () => {
             const outputSink = new OutputSink(options, NullLogger);
             const fixableError: ErrorDetails = {
                 reason: "REASON",
-                code: errorCodes.duplicateTarget,
+                code: ErrorCode.duplicateTarget,
                 fix: {
                     type: "replace",
                     line: 1,
@@ -713,7 +713,7 @@ describe("OutputSink", () => {
                 outputSink.startFile("foo.js");
                 outputSink.processError({
                     reason: "REASON",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -726,7 +726,7 @@ describe("OutputSink", () => {
                 outputSink.startFile("bar.js");
                 outputSink.processError({
                     reason: "REASON",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -764,7 +764,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.couldNotParse,
+                    code: ErrorCode.couldNotParse,
                 } as const;
                 outputSink.startFile("foo.js");
                 outputSink.processError(errorA);
@@ -772,7 +772,7 @@ describe("OutputSink", () => {
                 outputSink.startFile("bar.js");
                 const errorB1 = {
                     reason: "REASON_B1",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -784,7 +784,7 @@ describe("OutputSink", () => {
                 outputSink.processError(errorB1);
                 const errorB2 = {
                     reason: "REASON_B2",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     location: {
                         line: 42,
                         startColumn: 1,
@@ -832,7 +832,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.couldNotParse,
+                    code: ErrorCode.couldNotParse,
                 } as const;
                 outputSink.startFile("foo.js");
                 outputSink.processError(errorA);
@@ -847,7 +847,7 @@ describe("OutputSink", () => {
                 );
             });
 
-            it("should return ExitCodes.PARSE_ERRORS when there are unfixable errors", async () => {
+            it("should return ExitCode.PARSE_ERRORS when there are unfixable errors", async () => {
                 // Arrange
                 const NullLogger = new Logger();
                 jest.spyOn(FileReferenceLogger, "default").mockImplementation(
@@ -865,7 +865,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.couldNotParse,
+                    code: ErrorCode.couldNotParse,
                 } as const;
                 outputSink.startFile("foo.js");
                 outputSink.processError(errorA);
@@ -875,10 +875,10 @@ describe("OutputSink", () => {
                 const result = outputSink.end();
 
                 // Assert
-                expect(result).toBe(ExitCodes.PARSE_ERRORS);
+                expect(result).toBe(ExitCode.PARSE_ERRORS);
             });
 
-            it("should return ExitCodes.DESYNCHRONIZED_BLOCKS if there are fixable files and autoFix is false", async () => {
+            it("should return ExitCode.DESYNCHRONIZED_BLOCKS if there are fixable files and autoFix is false", async () => {
                 // Arrange
                 const NullLogger = new Logger();
                 jest.spyOn(FileReferenceLogger, "default").mockImplementation(
@@ -896,7 +896,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -913,10 +913,10 @@ describe("OutputSink", () => {
                 const result = outputSink.end();
 
                 // Assert
-                expect(result).toBe(ExitCodes.DESYNCHRONIZED_BLOCKS);
+                expect(result).toBe(ExitCode.DESYNCHRONIZED_BLOCKS);
             });
 
-            it("should return ExitCodes.SUCCESS if all errors are fixed", async () => {
+            it("should return ExitCode.SUCCESS if all errors are fixed", async () => {
                 // Arrange
                 const NullLogger = new Logger();
                 jest.spyOn(FileReferenceLogger, "default").mockImplementation(
@@ -936,7 +936,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -953,10 +953,10 @@ describe("OutputSink", () => {
                 const result = outputSink.end();
 
                 // Assert
-                expect(result).toBe(ExitCodes.SUCCESS);
+                expect(result).toBe(ExitCode.SUCCESS);
             });
 
-            it("should return ExitCodes.SUCCESS if there are no errors", () => {
+            it("should return ExitCode.SUCCESS if there are no errors", () => {
                 // Arrange
                 const NullLogger = new Logger();
                 const outputSink = new OutputSink(
@@ -972,7 +972,7 @@ describe("OutputSink", () => {
                 const result = outputSink.end();
 
                 // Assert
-                expect(result).toBe(ExitCodes.SUCCESS);
+                expect(result).toBe(ExitCode.SUCCESS);
             });
         });
 
@@ -1000,14 +1000,14 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.couldNotParse,
+                    code: ErrorCode.couldNotParse,
                 } as const;
                 outputSink.startFile("foo.js");
                 outputSink.processError(errorA);
                 outputSink.endFile();
                 const errorB1 = {
                     reason: "REASON_B",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -1063,7 +1063,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -1115,7 +1115,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.mismatchedChecksum,
+                    code: ErrorCode.mismatchedChecksum,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -1129,7 +1129,7 @@ describe("OutputSink", () => {
                 outputSink.endFile();
                 const errorB1 = {
                     reason: "REASON_B",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -1178,7 +1178,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -1237,7 +1237,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.couldNotParse,
+                    code: ErrorCode.couldNotParse,
                 } as const;
                 outputSink.startFile("foo.js");
                 outputSink.processError(errorA);
@@ -1256,7 +1256,7 @@ describe("OutputSink", () => {
                 `);
             });
 
-            it("should return ExitCodes.PARSE_ERRORS when there are unfixable errors", async () => {
+            it("should return ExitCode.PARSE_ERRORS when there are unfixable errors", async () => {
                 // Arrange
                 const NullLogger = new Logger();
                 jest.spyOn(FileReferenceLogger, "default").mockImplementation(
@@ -1274,7 +1274,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.couldNotParse,
+                    code: ErrorCode.couldNotParse,
                 } as const;
                 outputSink.startFile("foo.js");
                 outputSink.processError(errorA);
@@ -1284,10 +1284,10 @@ describe("OutputSink", () => {
                 const result = outputSink.end();
 
                 // Assert
-                expect(result).toBe(ExitCodes.PARSE_ERRORS);
+                expect(result).toBe(ExitCode.PARSE_ERRORS);
             });
 
-            it("should return ExitCodes.DESYNCHRONIZED_BLOCKS if there are fixable files and autoFix is false", async () => {
+            it("should return ExitCode.DESYNCHRONIZED_BLOCKS if there are fixable files and autoFix is false", async () => {
                 // Arrange
                 const NullLogger = new Logger();
                 jest.spyOn(FileReferenceLogger, "default").mockImplementation(
@@ -1306,7 +1306,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -1323,10 +1323,10 @@ describe("OutputSink", () => {
                 const result = outputSink.end();
 
                 // Assert
-                expect(result).toBe(ExitCodes.DESYNCHRONIZED_BLOCKS);
+                expect(result).toBe(ExitCode.DESYNCHRONIZED_BLOCKS);
             });
 
-            it("should return ExitCodes.SUCCESS if all errors are fixed", async () => {
+            it("should return ExitCode.SUCCESS if all errors are fixed", async () => {
                 // Arrange
                 const NullLogger = new Logger();
                 jest.spyOn(FileReferenceLogger, "default").mockImplementation(
@@ -1346,7 +1346,7 @@ describe("OutputSink", () => {
                 );
                 const errorA = {
                     reason: "REASON_A",
-                    code: errorCodes.duplicateTarget,
+                    code: ErrorCode.duplicateTarget,
                     fix: {
                         type: "replace",
                         line: 1,
@@ -1363,10 +1363,10 @@ describe("OutputSink", () => {
                 const result = outputSink.end();
 
                 // Assert
-                expect(result).toBe(ExitCodes.SUCCESS);
+                expect(result).toBe(ExitCode.SUCCESS);
             });
 
-            it("should return ExitCodes.SUCCESS if there are no errors", () => {
+            it("should return ExitCode.SUCCESS if there are no errors", () => {
                 // Arrange
                 const NullLogger = new Logger();
                 const outputSink = new OutputSink(
@@ -1382,7 +1382,7 @@ describe("OutputSink", () => {
                 const result = outputSink.end();
 
                 // Assert
-                expect(result).toBe(ExitCodes.SUCCESS);
+                expect(result).toBe(ExitCode.SUCCESS);
             });
         });
     });

--- a/src/__tests__/process-cache.test.ts
+++ b/src/__tests__/process-cache.test.ts
@@ -1,6 +1,6 @@
 import processCache from "../process-cache";
 import Logger from "../logger";
-import ExitCodes from "../exit-codes";
+import {ExitCode} from "../exit-codes";
 import * as OutputSink from "../output-sink";
 import * as GenerateErrorsForFile from "../generate-errors-for-file";
 
@@ -307,7 +307,7 @@ describe("#processCache", () => {
             startFile: jest.fn<any, any>(),
             processError: jest.fn<any, any>(),
             endFile: jest.fn<any, any>(),
-            end: jest.fn<any, any>().mockReturnValue(ExitCodes.CATASTROPHIC),
+            end: jest.fn<any, any>().mockReturnValue(ExitCode.CATASTROPHIC),
         } as const;
         jest.spyOn(OutputSink, "default").mockImplementation(
             () => fakeOutputSink,
@@ -322,6 +322,6 @@ describe("#processCache", () => {
         const result = await processCache(options, markerCache, NullLogger);
 
         // Assert
-        expect(result).toBe(ExitCodes.CATASTROPHIC);
+        expect(result).toBe(ExitCode.CATASTROPHIC);
     });
 });

--- a/src/__tests__/set-cwd.test.ts
+++ b/src/__tests__/set-cwd.test.ts
@@ -1,0 +1,39 @@
+import Logger from "../logger";
+import {ExitCode} from "../exit-codes";
+import setCwd from "../set-cwd";
+
+import * as Exit from "../exit";
+
+jest.mock("../exit");
+
+describe("setCwd", () => {
+    it("should set the current working directory", () => {
+        // Arrange
+        const NullLogger = new Logger(null, true);
+        const chdirSpy = jest.spyOn(process, "chdir");
+
+        // Act
+        setCwd(NullLogger, "some/path");
+
+        // Assert
+        expect(chdirSpy).toHaveBeenCalledWith("some/path");
+    });
+
+    it("should exit with ExitCode.CATASTROPHIC if cwd arg present and chdir fails", () => {
+        // Arrange
+        const NullLogger = new Logger(null, true);
+        const exitSpy = jest.spyOn(Exit, "default");
+        jest.spyOn(process, "chdir").mockImplementationOnce(() => {
+            throw new Error("PRETEND CHDIR FAIL!");
+        });
+
+        // Act
+        setCwd(NullLogger, "some/path");
+
+        // Assert
+        expect(exitSpy).toHaveBeenCalledWith(
+            expect.anything(),
+            ExitCode.CATASTROPHIC,
+        );
+    });
+});

--- a/src/check-sync.ts
+++ b/src/check-sync.ts
@@ -1,6 +1,6 @@
 import getMarkersFromFiles from "./get-markers-from-files";
 import getFiles from "./get-files";
-import ExitCodes, {ExitCode} from "./exit-codes";
+import {ExitCode} from "./exit-codes";
 import processCache from "./process-cache";
 
 import {ILog, Options} from "./types";
@@ -27,7 +27,7 @@ export default async function checkSync(
 
     if (files.length === 0) {
         log.error("No matching files");
-        return ExitCodes.NO_FILES;
+        return ExitCode.NO_FILES;
     }
 
     const cache = await getMarkersFromFiles(options, files);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import logHelp from "./help";
 import {version} from "../package.json";
 import determineOptions from "./determine-options";
 import exit from "./exit";
+import setCwd from "./set-cwd";
 
 /**
  * Run the command line.
@@ -96,13 +97,7 @@ export const run = (launchFilePath: string): Promise<void> => {
     // configuration file discovery and other tasks will be working off a
     // different working directory.
     if (args.cwd != null) {
-        log.verbose(() => `Changing working directory to ${args.cwd}`);
-        try {
-            process.chdir(args.cwd);
-        } catch (e) {
-            log.error(`Unable to set working directory: ${e}`);
-            exit(log, ExitCode.CATASTROPHIC);
-        }
+        setCwd(log, args.cwd);
     }
 
     // Parse arguments and configurations to get our options.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,10 +6,11 @@ import chalk from "chalk";
 import minimist from "minimist";
 import checkSync from "./check-sync";
 import Logger from "./logger";
-import ExitCodes from "./exit-codes";
+import {ExitCode} from "./exit-codes";
 import logHelp from "./help";
 import {version} from "../package.json";
 import determineOptions from "./determine-options";
+import exit from "./exit";
 
 /**
  * Run the command line.
@@ -26,7 +27,14 @@ export const run = (launchFilePath: string): Promise<void> => {
     // as a flag inversion of the none-`no` version.
     const args = minimist(process.argv, {
         boolean: ["updateTags", "dryRun", "help", "verbose", "version", "json"],
-        string: ["comments", "rootMarker", "ignore", "ignoreFiles", "config"],
+        string: [
+            "cwd",
+            "comments",
+            "rootMarker",
+            "ignore",
+            "ignoreFiles",
+            "config",
+        ],
         alias: {
             comments: ["c"],
             dryRun: ["n", "dry-run"],
@@ -62,7 +70,7 @@ export const run = (launchFilePath: string): Promise<void> => {
 
             if (arg.startsWith("-")) {
                 log.error(`Unknown argument: ${arg}`);
-                process.exit(ExitCodes.UNKNOWN_ARGS);
+                exit(log, ExitCode.UNKNOWN_ARGS);
             }
             return true;
         },
@@ -74,33 +82,44 @@ export const run = (launchFilePath: string): Promise<void> => {
     // Process arguments that fail early.
     if (args.version) {
         log.log(version);
-        process.exit(ExitCodes.SUCCESS);
+        exit(log, ExitCode.SUCCESS);
     }
 
     if (args.help) {
         logHelp(log);
-        process.exit(ExitCodes.SUCCESS);
+        exit(log, ExitCode.SUCCESS);
     }
 
     log.verbose(() => `Launched with args: ${JSON.stringify(args, null, 4)}`);
+
+    // We need to apply the cwd argument to the process, otherwise the
+    // configuration file discovery and other tasks will be working off a
+    // different working directory.
+    if (args.cwd != null) {
+        log.verbose(() => `Changing working directory to ${args.cwd}`);
+        try {
+            process.chdir(args.cwd);
+        } catch (e) {
+            log.error(`Unable to set working directory: ${e}`);
+            exit(log, ExitCode.CATASTROPHIC);
+        }
+    }
 
     // Parse arguments and configurations to get our options.
     return determineOptions(args, log)
         .then(
             (options) => checkSync(options, log),
-            (e) => ExitCodes.BAD_CONFIG,
+            (e) => ExitCode.BAD_CONFIG,
         )
         .then(
             (exitCode) => {
                 log.verbose(() => `Exiting with code ${exitCode}`);
-                process.exit(exitCode);
+                exit(log, exitCode);
             },
             (e) => {
                 log.error(`Unexpected error: ${e}`);
-                log.verbose(
-                    () => `Exiting with code ${ExitCodes.CATASTROPHIC}`,
-                );
-                process.exit(ExitCodes.CATASTROPHIC);
+                log.verbose(() => `Exiting with code ${ExitCode.CATASTROPHIC}`);
+                exit(log, ExitCode.CATASTROPHIC);
             },
         );
 };

--- a/src/determine-options.ts
+++ b/src/determine-options.ts
@@ -5,6 +5,8 @@ import {optionsFromArgs} from "./options-from-args";
 
 import {ILog, Options} from "./types";
 import {ParsedArgs} from "minimist";
+import path from "path";
+import setCwd from "./set-cwd";
 
 export default async function determineOptions(
     args: ParsedArgs,
@@ -33,6 +35,17 @@ export default async function determineOptions(
             return `Using --config file: ${configFilePath}`;
         }
     });
+
+    if (configFilePath != null) {
+        // We found a config file.
+        // In order for paths defined in the config file to work
+        // deterministically, we need to make sure the current working
+        // directory is that of the config file.
+        // This is intended to override the --cwd argument, so it
+        // is expected that the cwd may change twice if there is a --cwd
+        // argument that then discovers a config file.
+        setCwd(log, path.dirname(configFilePath));
+    }
 
     const configFromFile =
         configFilePath == null

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -1,22 +1,18 @@
-export const errorCodes = Object.freeze({
-    couldNotParse: "could-not-parse",
-    malformedStartTag: "malformed-start-tag",
-    malformedEndTag: "malformed-end-tag",
-    endTagWithoutStartTag: "end-tag-without-start-tag",
+export enum ErrorCode {
+    couldNotParse = "could-not-parse",
+    malformedStartTag = "malformed-start-tag",
+    malformedEndTag = "malformed-end-tag",
+    endTagWithoutStartTag = "end-tag-without-start-tag",
 
-    emptyMarker: "empty-marker",
-    duplicateMarker: "duplicate-marker",
-    startTagWithoutEndTag: "start-tag-witout-end-tag",
+    emptyMarker = "empty-marker",
+    duplicateMarker = "duplicate-marker",
+    startTagWithoutEndTag = "start-tag-witout-end-tag",
 
-    mismatchedChecksum: "mismatched-checksum",
-    duplicateTarget: "duplicate-target",
-    startTagAfterContent: "start-tag-after-content",
-    fileDoesNotExist: "file-does-not-exist",
-    noReturnTag: "no-return-tag",
-    selfTargeting: "self-targeting",
-    differentCommentSyntax: "different-comment-syntax",
-});
-
-export type ErrorCode = (typeof errorCodes)[keyof typeof errorCodes];
-
-export default errorCodes;
+    mismatchedChecksum = "mismatched-checksum",
+    duplicateTarget = "duplicate-target",
+    startTagAfterContent = "start-tag-after-content",
+    fileDoesNotExist = "file-does-not-exist",
+    noReturnTag = "no-return-tag",
+    selfTargeting = "self-targeting",
+    differentCommentSyntax = "different-comment-syntax",
+}

--- a/src/exit-codes.ts
+++ b/src/exit-codes.ts
@@ -1,16 +1,12 @@
 /**
  * Exit codes that can be exited with.
  */
-const exitCodes = {
-    SUCCESS: 0,
-    NO_FILES: 1,
-    PARSE_ERRORS: 2,
-    DESYNCHRONIZED_BLOCKS: 3,
-    UNKNOWN_ARGS: 4,
-    CATASTROPHIC: 5,
-    BAD_CONFIG: 6,
-} as const;
-
-export type ExitCode = (typeof exitCodes)[keyof typeof exitCodes];
-
-export default exitCodes;
+export enum ExitCode {
+    SUCCESS = 0,
+    NO_FILES = 1,
+    PARSE_ERRORS = 2,
+    DESYNCHRONIZED_BLOCKS = 3,
+    UNKNOWN_ARGS = 4,
+    CATASTROPHIC = 5,
+    BAD_CONFIG = 6,
+}

--- a/src/exit.ts
+++ b/src/exit.ts
@@ -1,0 +1,14 @@
+import {ExitCode} from "./exit-codes";
+import {ILog} from "./types";
+
+/**
+ * Exit the process with the given exit code.
+ *
+ * @param log The log to use for logging.
+ * @param code The exit code to exit with.
+ * @returns Never. The process exits.
+ */
+export default function exit(log: ILog, code: ExitCode): never {
+    log.verbose(() => `Exiting with code ${code}: ${ExitCode[code]}`);
+    process.exit(code);
+}

--- a/src/generate-errors-for-file.ts
+++ b/src/generate-errors-for-file.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import escapeRegExp from "lodash/escapeRegExp";
-import ErrorCodes from "./error-codes";
+import {ErrorCode} from "./error-codes";
 import rootRelativePath from "./root-relative-path";
 import cwdRelativePath from "./cwd-relative-path";
 import {NoChecksum} from "./types";
@@ -102,7 +102,7 @@ export default function* generateErrors(
                     reason: `No return tag named '${markerID}' in '${cwdRelativePath(
                         targetRef.file,
                     )}'`,
-                    code: "no-return-tag",
+                    code: ErrorCode.noReturnTag,
                     location: {line: sourceLine},
                 };
                 continue;
@@ -125,7 +125,7 @@ export default function* generateErrors(
             )}${commentEnd || ""}`;
 
             yield {
-                code: ErrorCodes.mismatchedChecksum,
+                code: ErrorCode.mismatchedChecksum,
                 reason: `Looks like you changed the target content for sync-tag '${markerID}' in '${cwdRelativePath(
                     normalizedTargetFile,
                 )}:${

--- a/src/get-markers-from-files.ts
+++ b/src/get-markers-from-files.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import parseFile from "./parse-file";
 
 import {FileInfo, MarkerCache, Options} from "./types";
+import {ErrorCode} from "./error-codes";
 
 /**
  * Generate a marker cache from the given files.
@@ -79,7 +80,7 @@ export default async function getMarkersFromFiles(
                     aliases: [],
                     errors: [
                         {
-                            code: "could-not-parse",
+                            code: ErrorCode.couldNotParse,
                             reason: `Could not parse ${file}: ${e.message}`,
                         },
                     ],

--- a/src/help.ts
+++ b/src/help.ts
@@ -69,6 +69,21 @@ Where:
                                .map((n) => `\`${n}\``)
                                .join("\n                           ")}
 
+                       Paths within the config file are resolved relative to
+                       the location of the config file.
+
+    \`--cwd\`              The current working directory to use when searching
+                       for a configuration file, and resolving relative paths
+                       and globs.
+
+                       The \`--config\` path takes precedence over this
+                       argument. If there is no \`--config\` argument, this
+                       location is used to find a config file. If a config file
+                       is found, the working directory will then change to
+                       the location of that file, otherwise this argument's
+                       value is used when resolve the remainder of the given
+                       arguments.
+
     \`--dry-run,-n\`       Ignored unless supplied with \`--update-tags\`.
 
     \`--help,-h\`          Outputs this help text.

--- a/src/marker-parser.ts
+++ b/src/marker-parser.ts
@@ -2,7 +2,7 @@ import escapeRegExp from "lodash/escapeRegExp";
 
 import calcChecksum from "./checksum";
 import {NoChecksum} from "./types";
-import ErrorCodes from "./error-codes";
+import {ErrorCode} from "./error-codes";
 
 import {Targets, normalizePathFn, ErrorDetails} from "./types";
 
@@ -226,7 +226,7 @@ export default class MarkerParser {
             this._recordError({
                 reason: `Sync-start tags for '${id}' given in different comment styles. Please use the same style for all sync-start tags that have identical identifiers.`,
                 location: {line},
-                code: ErrorCodes.differentCommentSyntax,
+                code: ErrorCode.differentCommentSyntax,
             });
         }
 
@@ -234,7 +234,7 @@ export default class MarkerParser {
             this._recordError({
                 reason: `Sync-start for '${id}' points to '${file}', which does not exist or is a directory`,
                 location: {line},
-                code: ErrorCodes.fileDoesNotExist,
+                code: ErrorCode.fileDoesNotExist,
             });
         }
 
@@ -242,7 +242,7 @@ export default class MarkerParser {
             this._recordError({
                 reason: `Duplicate target for sync-tag '${id}'`,
                 location: {line},
-                code: ErrorCodes.duplicateTarget,
+                code: ErrorCode.duplicateTarget,
                 fix: {
                     type: "delete",
                     description: `Removed duplicate target for sync-tag '${id}'`,
@@ -256,7 +256,7 @@ export default class MarkerParser {
             this._recordError({
                 reason: `Sync-start for '${id}' found after content started`,
                 location: {line},
-                code: ErrorCodes.startTagAfterContent,
+                code: ErrorCode.startTagAfterContent,
             });
         }
         const targets = this._openMarkers[id].targets[normalized.file] || [];
@@ -274,13 +274,13 @@ export default class MarkerParser {
             this._recordError({
                 reason: `Sync-end for '${id}' found, but there was no corresponding sync-start`,
                 location: {line},
-                code: ErrorCodes.endTagWithoutStartTag,
+                code: ErrorCode.endTagWithoutStartTag,
             });
         } else if (marker.content.length === 0) {
             this._recordError({
                 reason: `Sync-tag '${id}' has no content`,
                 location: {line},
-                code: ErrorCodes.emptyMarker,
+                code: ErrorCode.emptyMarker,
             });
         }
 
@@ -301,7 +301,7 @@ export default class MarkerParser {
             this._recordError({
                 reason: `Sync-start '${id}' has no corresponding sync-end`,
                 location: {line},
-                code: ErrorCodes.startTagWithoutEndTag,
+                code: ErrorCode.startTagWithoutEndTag,
             });
         }
     };
@@ -314,7 +314,7 @@ export default class MarkerParser {
         this._recordError({
             reason: `Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'`,
             location: {line},
-            code: ErrorCodes.malformedStartTag,
+            code: ErrorCode.malformedStartTag,
         });
     };
 
@@ -325,7 +325,7 @@ export default class MarkerParser {
         this._recordError({
             reason: `Malformed sync-end: format should be 'sync-end:<label>'`,
             location: {line},
-            code: ErrorCodes.malformedEndTag,
+            code: ErrorCode.malformedEndTag,
         });
     };
 

--- a/src/output-sink.ts
+++ b/src/output-sink.ts
@@ -1,12 +1,12 @@
 import FileReferenceLogger from "./file-reference-logger";
 import maybeReportError from "./maybe-report-error";
-import ExitCodes, {ExitCode} from "./exit-codes";
+import {ExitCode} from "./exit-codes";
 import defaultOptions from "./default-options";
 import getLaunchString from "./get-launch-string";
 import cwdRelativePath from "./cwd-relative-path";
 import {version} from "../package.json";
 import fixFile from "./fix-file";
-import ErrorCodes from "./error-codes";
+import {ErrorCode} from "./error-codes";
 import rootRelativePath from "./root-relative-path";
 
 import {ErrorDetails, Options, ILog, ErrorDetailsByDeclaration} from "./types";
@@ -86,7 +86,7 @@ export default class OutputSink {
             this._fixableFileNames.add(fileLog.file);
 
             if (!this._options.autoFix && !this._options.json) {
-                if (code === ErrorCodes.mismatchedChecksum) {
+                if (code === ErrorCode.mismatchedChecksum) {
                     fileLog.mismatch(reason, fix.line);
                 } else {
                     fileLog.warn(reason, fix.line);
@@ -254,18 +254,18 @@ export default class OutputSink {
 
         // Determine the exit code.
         if (this._filesWithUnfixableErrors.size > 0) {
-            return ExitCodes.PARSE_ERRORS;
+            return ExitCode.PARSE_ERRORS;
         }
         if (this._fixableFileNames.size > 0 && !this._options.autoFix) {
             // We have files that can be fixed and we aren't autofixing them
             // so report desynchronized blocks.
-            return ExitCodes.DESYNCHRONIZED_BLOCKS;
+            return ExitCode.DESYNCHRONIZED_BLOCKS;
         }
 
         if (!this._options.json) {
             // If we get here, everything worked.
             this._mainLog.log("🎉  Everything is in sync!");
         }
-        return ExitCodes.SUCCESS;
+        return ExitCode.SUCCESS;
     }
 }

--- a/src/parse-file.ts
+++ b/src/parse-file.ts
@@ -6,7 +6,7 @@ import fs from "fs";
 
 import MarkerParser from "./marker-parser";
 import getNormalizedTargetFileInfo from "./get-normalized-target-file-info";
-import ErrorCodes from "./error-codes";
+import {ErrorCode} from "./error-codes";
 import {ancesdirOrCurrentDir} from "./ancesdir-or-currentdir";
 
 import {
@@ -58,7 +58,7 @@ export default function parseFile(
                     location: {
                         line: lineNumber,
                     },
-                    code: ErrorCodes.duplicateMarker,
+                    code: ErrorCode.duplicateMarker,
                 });
             }
 
@@ -69,7 +69,7 @@ export default function parseFile(
                     location: {
                         line: lineNumber,
                     },
-                    code: ErrorCodes.selfTargeting,
+                    code: ErrorCode.selfTargeting,
                 });
             }
         }
@@ -140,7 +140,7 @@ export default function parseFile(
         (res) => res,
         (reason: Error) => {
             recordError({
-                code: "could-not-parse",
+                code: ErrorCode.couldNotParse,
                 reason: `Could not parse file: ${reason.message}`,
             });
             return {

--- a/src/set-cwd.ts
+++ b/src/set-cwd.ts
@@ -1,0 +1,21 @@
+import exit from "./exit";
+import {ExitCode} from "./exit-codes";
+import {ILog} from "./types";
+
+/**
+ * Set the current working directory.
+ *
+ * This will exit the process if the directory cannot be changed.
+ *
+ * @param log A log to record things
+ * @param directory The directory to set as the current working directory.
+ */
+export default function setCwd(log: ILog, directory: string): void {
+    log.verbose(() => `Changing working directory to ${directory}`);
+    try {
+        process.chdir(directory);
+    } catch (e) {
+        log.error(`Unable to set working directory: ${e}`);
+        exit(log, ExitCode.CATASTROPHIC);
+    }
+}


### PR DESCRIPTION
## Summary:
This adds a new `--cwd` argument to override the current working directory that checksync uses.

More importantly, it now sets the current working directory to the location of the configuration file, if one is loaded. This ensures that paths/globs specified in a configuration file are interpreted relative to the configuration file, not the current working directory, which makes it a lot easier to reason about the configuration file definition.

Issue: fixes #1262

## Test plan:
`yarn test`