### PR TITLE
[🔥AUDIT🔥] [fixrollup] Fix rollup configuration

### DIFF
--- a/.changeset/chilled-sheep-shop.md
+++ b/.changeset/chilled-sheep-shop.md
@@ -1,0 +1,5 @@
+---
+"checksync": patch
+---
+
+Fix rollup config to bundle deps

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,10 @@ export default {
     },
     plugins: [
         json(),
-        resolve({preferBuiltins: true, extensions: [".ts"]}),
+        resolve({
+            preferBuiltins: true,
+            extensions: [".ts", ".mjs", ".js", ".json", ".node"],
+        }),
         babel({
             configFile: "./babel.config.js",
             extensions: [".ts"],


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Before this change, we were not inlining our external deps. This was down to the `plugin-node-resolve` behavior once the `extensions` array was given to add support for TypeScript files as I had not included the defaults. The defaults are now included.

Issue: XXX-XXXX

## Test plan:
`yarn build` and verify that it works.