### PR TITLE
[emptytags] Add allowEmptyTags config

### DIFF
--- a/.changeset/smooth-cats-itch.md
+++ b/.changeset/smooth-cats-itch.md
@@ -1,0 +1,5 @@
+---
+"checksync": patch
+---
+
+Add support for empty tags. This is a non-breaking change. The configuration must be updated to allow this.

--- a/__examples__/empty_tag/a.js
+++ b/__examples__/empty_tag/a.js
@@ -1,0 +1,3 @@
+// This is a a javascript (or similar language) file
+// sync-start:no_content 1462105647 __examples__/empty_tag/b.js
+// sync-end:no_content

--- a/__examples__/empty_tag/b.js
+++ b/__examples__/empty_tag/b.js
@@ -1,0 +1,4 @@
+// This is a a javascript (or similar language) file
+// sync-start:no_content 720907 __examples__/empty_tag/a.js
+console.log("Hello, world!");
+// sync-end:no_content

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,5 +23,7 @@ module.exports = {
         enableGlobally: true,
     },
 
+    prettierPath: null,
+
     setupFilesAfterEnv: ["jest-extended/all", "./jest.setup.js"],
 };

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -11,7 +11,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -57,7 +57,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -107,7 +107,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -204,7 +204,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -258,7 +258,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -311,7 +311,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -423,7 +423,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -453,7 +453,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -484,7 +484,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -518,7 +518,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -554,7 +554,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -591,7 +591,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -642,7 +642,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -686,7 +686,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -731,7 +731,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -813,6 +813,119 @@ Verbose  Discovered paths: [
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) should report example empty_tag to match snapshot 1`] = `
+"Verbose  Options from arguments: {"includeGlobs":["**/empty_tag/**"]}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/empty_tag/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/empty_tag/a.js",
+    "ROOT_DIR/__examples__/empty_tag/b.js"
+]
+Error    __examples__/empty_tag/a.js:3
+Sync-tag 'no_content' has no content
+
+<group 🛑  Unfixable errors found. Fix the errors in these files and try again. >
+  __examples__/empty_tag/a.js
+<end_group>"
+`;
+
+exports[`Integration Tests (see __examples__ folder) should report example empty_tag to match snapshot with autofix dryrun 1`] = `
+"Verbose  Options from arguments: {"includeGlobs":["**/empty_tag/**"],"autoFix":true,"dryRun":true}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Info     DRY-RUN: Files will not be modified
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/empty_tag/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/empty_tag/a.js",
+    "ROOT_DIR/__examples__/empty_tag/b.js"
+]
+Error    __examples__/empty_tag/a.js:3
+Sync-tag 'no_content' has no content
+
+<group 🛑  Could not update all tags due to unfixable errors. Fix the errors in these files and try again. >
+  __examples__/empty_tag/a.js
+<end_group>"
+`;
+
+exports[`Integration Tests (see __examples__ folder) should report example empty_tag to match snapshot with json 1`] = `
+"Verbose  Options from arguments: {"includeGlobs":["**/empty_tag/**"],"json":true}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/empty_tag/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/empty_tag/a.js",
+    "ROOT_DIR/__examples__/empty_tag/b.js"
+]
+Error    🛑  Unfixable errors found. Fix the errors and try again.
+{
+    "version": "0.0.0",
+    "launchString": "checksync -u ",
+    "files": {
+        "__examples__/empty_tag/a.js": [
+            {
+                "reason": "Sync-tag 'no_content' has no content",
+                "location": {
+                    "line": 3
+                },
+                "code": "empty-marker"
+            }
+        ]
+    }
+}"
+`;
+
 exports[`Integration Tests (see __examples__ folder) should report example end_with_no_start to match snapshot 1`] = `
 "Verbose  Options from arguments: {"includeGlobs":["**/end_with_no_start/**"]}
 Verbose  Looking for configuration file based on root marker...
@@ -824,7 +937,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -857,7 +970,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -891,7 +1004,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -934,7 +1047,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -960,7 +1073,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -987,7 +1100,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1013,7 +1126,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1053,7 +1166,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1094,7 +1207,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1144,7 +1257,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1185,7 +1298,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1227,7 +1340,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1294,7 +1407,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1341,7 +1454,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1389,7 +1502,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1473,7 +1586,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1508,7 +1621,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1544,7 +1657,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1594,7 +1707,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1628,7 +1741,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1663,7 +1776,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1707,7 +1820,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1746,7 +1859,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1789,7 +1902,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1855,7 +1968,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1896,7 +2009,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1935,7 +2048,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1992,7 +2105,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -2029,7 +2142,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -2067,7 +2180,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -11,7 +11,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -57,7 +57,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -107,7 +107,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -204,7 +204,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -258,7 +258,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -311,7 +311,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -423,7 +423,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -453,7 +453,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -484,7 +484,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -518,7 +518,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -554,7 +554,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -591,7 +591,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -642,7 +642,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -686,7 +686,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -731,7 +731,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -824,7 +824,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -858,7 +858,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -893,7 +893,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -937,7 +937,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -970,7 +970,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1004,7 +1004,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1047,7 +1047,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1073,7 +1073,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1100,7 +1100,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1126,7 +1126,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1166,7 +1166,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1207,7 +1207,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1257,7 +1257,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1298,7 +1298,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1340,7 +1340,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1407,7 +1407,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1454,7 +1454,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1502,7 +1502,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1586,7 +1586,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1621,7 +1621,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1657,7 +1657,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1707,7 +1707,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1741,7 +1741,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1776,7 +1776,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1820,7 +1820,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1859,7 +1859,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1902,7 +1902,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1968,7 +1968,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -2009,7 +2009,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -2048,7 +2048,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -2105,7 +2105,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -2142,7 +2142,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -2180,7 +2180,7 @@ Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
 Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTargets":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"

--- a/src/__tests__/check-sync.test.ts
+++ b/src/__tests__/check-sync.test.ts
@@ -30,6 +30,7 @@ describe("#checkSync", () => {
                 autoFix: true,
                 comments: ["//"],
                 json: false,
+                allowEmptyTargets: false,
             },
             NullLogger,
         );
@@ -57,6 +58,7 @@ describe("#checkSync", () => {
                 autoFix: true,
                 comments: ["//"],
                 json: false,
+                allowEmptyTargets: false,
             },
             NullLogger,
         );
@@ -83,6 +85,7 @@ describe("#checkSync", () => {
             autoFix: false,
             comments: ["//"],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -104,6 +107,7 @@ describe("#checkSync", () => {
             autoFix: false,
             comments: ["//"],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -129,6 +133,7 @@ describe("#checkSync", () => {
             autoFix: true,
             comments: ["//"],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -159,6 +164,7 @@ describe("#checkSync", () => {
             comments: ["//"],
             rootMarker: "marker",
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -190,6 +196,7 @@ describe("#checkSync", () => {
                 comments: ["//"],
                 dryRun: false,
                 json: false,
+                allowEmptyTargets: false,
             },
             NullLogger,
         );

--- a/src/__tests__/check-sync.test.ts
+++ b/src/__tests__/check-sync.test.ts
@@ -30,7 +30,7 @@ describe("#checkSync", () => {
                 autoFix: true,
                 comments: ["//"],
                 json: false,
-                allowEmptyTargets: false,
+                allowEmptyTags: false,
             },
             NullLogger,
         );
@@ -58,7 +58,7 @@ describe("#checkSync", () => {
                 autoFix: true,
                 comments: ["//"],
                 json: false,
-                allowEmptyTargets: false,
+                allowEmptyTags: false,
             },
             NullLogger,
         );
@@ -85,7 +85,7 @@ describe("#checkSync", () => {
             autoFix: false,
             comments: ["//"],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -107,7 +107,7 @@ describe("#checkSync", () => {
             autoFix: false,
             comments: ["//"],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -133,7 +133,7 @@ describe("#checkSync", () => {
             autoFix: true,
             comments: ["//"],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -164,7 +164,7 @@ describe("#checkSync", () => {
             comments: ["//"],
             rootMarker: "marker",
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -196,7 +196,7 @@ describe("#checkSync", () => {
                 comments: ["//"],
                 dryRun: false,
                 json: false,
-                allowEmptyTargets: false,
+                allowEmptyTags: false,
             },
             NullLogger,
         );

--- a/src/__tests__/default-options.test.ts
+++ b/src/__tests__/default-options.test.ts
@@ -28,7 +28,7 @@ describe("defaultOptions", () => {
         // Assert
         expect(result).toMatchInlineSnapshot(`
 {
-  "allowEmptyTargets": false,
+  "allowEmptyTags": false,
   "autoFix": false,
   "comments": [
     "#",

--- a/src/__tests__/default-options.test.ts
+++ b/src/__tests__/default-options.test.ts
@@ -27,23 +27,24 @@ describe("defaultOptions", () => {
 
         // Assert
         expect(result).toMatchInlineSnapshot(`
-            {
-              "autoFix": false,
-              "comments": [
-                "#",
-                "//",
-                "{/*",
-              ],
-              "dryRun": false,
-              "excludeGlobs": [],
-              "ignoreFiles": [
-                ".gitignore",
-              ],
-              "includeGlobs": [
-                "/**",
-              ],
-              "json": false,
-            }
-        `);
+{
+  "allowEmptyTargets": false,
+  "autoFix": false,
+  "comments": [
+    "#",
+    "//",
+    "{/*",
+  ],
+  "dryRun": false,
+  "excludeGlobs": [],
+  "ignoreFiles": [
+    ".gitignore",
+  ],
+  "includeGlobs": [
+    "/**",
+  ],
+  "json": false,
+}
+`);
     });
 });

--- a/src/__tests__/fix-file.test.ts
+++ b/src/__tests__/fix-file.test.ts
@@ -38,7 +38,7 @@ describe("#fixFile", () => {
         comments: [],
         rootMarker: null,
         json: false,
-        allowEmptyTargets: false,
+        allowEmptyTags: false,
     };
 
     it("should resolve if there are no mismatches for file", async () => {

--- a/src/__tests__/fix-file.test.ts
+++ b/src/__tests__/fix-file.test.ts
@@ -38,6 +38,7 @@ describe("#fixFile", () => {
         comments: [],
         rootMarker: null,
         json: false,
+        allowEmptyTargets: false,
     };
 
     it("should resolve if there are no mismatches for file", async () => {

--- a/src/__tests__/get-markers-from-files.test.ts
+++ b/src/__tests__/get-markers-from-files.test.ts
@@ -24,7 +24,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -61,7 +61,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -94,7 +94,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -130,7 +130,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -187,7 +187,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -243,7 +243,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -300,7 +300,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -347,7 +347,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act

--- a/src/__tests__/get-markers-from-files.test.ts
+++ b/src/__tests__/get-markers-from-files.test.ts
@@ -24,6 +24,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -60,6 +61,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -92,6 +94,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -127,6 +130,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -183,6 +187,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -238,6 +243,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -294,6 +300,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -340,6 +347,7 @@ describe("#fromFiles", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act

--- a/src/__tests__/options-from-args.test.ts
+++ b/src/__tests__/options-from-args.test.ts
@@ -252,4 +252,30 @@ describe("#optionsFromArgs", () => {
         // Assert
         expect(result.rootMarker).toBe("ROOT_MARKER");
     });
+
+    it("should not add allowEmptyTags if args.allowEmptyTags is not provided", () => {
+        // Arrange
+        const args: any = {
+            allowEmptyTags: null,
+        };
+
+        // Act
+        const result = optionsFromArgs(args);
+
+        // Assert
+        expect(result.allowEmptyTags).not.toBeDefined();
+    });
+
+    it("should add allowEmptyTags if args.allowEmptyTags is provided", () => {
+        // Arrange
+        const args: any = {
+            allowEmptyTags: false,
+        };
+
+        // Act
+        const result = optionsFromArgs(args);
+
+        // Assert
+        expect(result.allowEmptyTags).toBe(false);
+    });
 });

--- a/src/__tests__/parse-file.test.ts
+++ b/src/__tests__/parse-file.test.ts
@@ -8,6 +8,7 @@ import * as GetNormalizedTargetFileInfo from "../get-normalized-target-file-info
 import parseFile from "../parse-file";
 
 import {Options} from "../types";
+import {ErrorCode} from "../error-codes";
 
 jest.mock("fs");
 jest.mock("../get-normalized-target-file-info");
@@ -57,6 +58,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -80,6 +82,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -114,6 +117,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -145,6 +149,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -186,6 +191,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -224,6 +230,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -261,6 +268,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -311,6 +319,102 @@ describe("#parseFile", () => {
         });
     });
 
+    it("should record empty marker error if allowEmptyTargets is false", async () => {
+        // Arrange
+        const fakeInterface: any = {on: jest.fn<any, any>()} as const;
+        fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
+        jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null as any);
+        jest.spyOn(readline, "createInterface").mockReturnValueOnce(
+            fakeInterface,
+        );
+        const finishReadingFile = () => invokeEvent(fakeInterface.on, "close");
+        const markerParserSpy = jest.spyOn(MarkerParser, "default");
+        setupMarkerParser();
+        const options: Options = {
+            includeGlobs: ["a.js", "b.js"],
+            comments: [],
+            autoFix: true,
+            rootMarker: null,
+            dryRun: false,
+            excludeGlobs: [],
+            ignoreFiles: [],
+            json: false,
+            allowEmptyTargets: false,
+        };
+
+        // Act
+        const promise = parseFile(options, "file.js", true);
+        const recorderror = markerParserSpy.mock.calls[0][2];
+        recorderror({
+            code: ErrorCode.emptyMarker,
+            location: {line: 1},
+            reason: "Sync-tag 'MARKER_ID1' has no content",
+        });
+        finishReadingFile();
+        const result = await promise;
+
+        // Assert
+        expect(result).toStrictEqual({
+            errors: [
+                {
+                    code: ErrorCode.emptyMarker,
+                    location: {line: 1},
+                    reason: "Sync-tag 'MARKER_ID1' has no content",
+                },
+            ],
+            markers: null,
+            readOnly: true,
+            referencedFiles: [],
+            lineCount: 0,
+        });
+    });
+
+    it("should not record empty marker error if allowEmptyTargets is true", async () => {
+        // Arrange
+        const fakeInterface: any = {on: jest.fn<any, any>()} as const;
+        fakeInterface.on.mockReturnValue(fakeInterface);
+        jest.spyOn(fs, "openSync").mockReturnValueOnce(0);
+        jest.spyOn(fs, "createReadStream").mockReturnValueOnce(null as any);
+        jest.spyOn(readline, "createInterface").mockReturnValueOnce(
+            fakeInterface,
+        );
+        const finishReadingFile = () => invokeEvent(fakeInterface.on, "close");
+        const markerParserSpy = jest.spyOn(MarkerParser, "default");
+        setupMarkerParser();
+        const options: Options = {
+            includeGlobs: ["a.js", "b.js"],
+            comments: [],
+            autoFix: true,
+            rootMarker: null,
+            dryRun: false,
+            excludeGlobs: [],
+            ignoreFiles: [],
+            json: false,
+            allowEmptyTargets: true,
+        };
+
+        // Act
+        const promise = parseFile(options, "file.js", true);
+        const recorderror = markerParserSpy.mock.calls[0][2];
+        recorderror({
+            code: ErrorCode.emptyMarker,
+            location: {line: 1},
+            reason: "Sync-tag 'MARKER_ID1' has no content",
+        });
+        finishReadingFile();
+        const result = await promise;
+
+        // Assert
+        expect(result).toStrictEqual({
+            errors: [],
+            markers: null,
+            readOnly: true,
+            referencedFiles: [],
+            lineCount: 0,
+        });
+    });
+
     it("should normalize referenced files for marker parser", async () => {
         // Arrange
         const fakeInterface: any = {on: jest.fn<any, any>()} as const;
@@ -339,6 +443,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -383,6 +488,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -425,6 +531,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
 
         // Act
@@ -460,6 +567,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
         const promise = parseFile(options, "file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -550,6 +658,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
+            allowEmptyTargets: false,
         };
         const promise = parseFile(options, "file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];

--- a/src/__tests__/parse-file.test.ts
+++ b/src/__tests__/parse-file.test.ts
@@ -58,7 +58,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -82,7 +82,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -117,7 +117,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -149,7 +149,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -191,7 +191,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -230,7 +230,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -268,7 +268,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -340,7 +340,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -391,7 +391,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: true,
+            allowEmptyTags: true,
         };
 
         // Act
@@ -443,7 +443,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -488,7 +488,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -531,7 +531,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
 
         // Act
@@ -567,7 +567,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
         const promise = parseFile(options, "file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -658,7 +658,7 @@ describe("#parseFile", () => {
             excludeGlobs: [],
             ignoreFiles: [],
             json: false,
-            allowEmptyTargets: false,
+            allowEmptyTags: false,
         };
         const promise = parseFile(options, "file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];

--- a/src/checksync.schema.json
+++ b/src/checksync.schema.json
@@ -80,6 +80,11 @@
             "description": "The string that identifies the root of the project from which all sync-tags are relative",
             "type": "string",
             "pattern": "^[^/\\\\]+$"
+        },
+        "allowEmptyTags": {
+            "description": "When true, checksync will not report an error if a sync-tag is empty",
+            "type": "boolean",
+            "default": false
         }
     },
     "required": [],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ export const run = (launchFilePath: string): Promise<void> => {
             "ignore",
             "ignoreFiles",
             "config",
+            "allowEmptyTags",
         ],
         alias: {
             comments: ["c"],
@@ -45,6 +46,7 @@ export const run = (launchFilePath: string): Promise<void> => {
             json: ["j"],
             rootMarker: ["m", "root-marker"],
             updateTags: ["u", "update-tags"],
+            allowEmptyTags: ["a", "allow-empty-tags"],
         },
         unknown: (arg) => {
             // Filter out the node process.

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -2,6 +2,7 @@ import {Options} from "./types";
 const defaultOptions: Options = {
     autoFix: false,
     json: false,
+    allowEmptyTargets: false,
     comments: ["#", "//", "{/*"],
     excludeGlobs: [],
     dryRun: false,

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -2,7 +2,7 @@ import {Options} from "./types";
 const defaultOptions: Options = {
     autoFix: false,
     json: false,
-    allowEmptyTargets: false,
+    allowEmptyTags: false,
     comments: ["#", "//", "{/*"],
     excludeGlobs: [],
     dryRun: false,

--- a/src/options-from-args.ts
+++ b/src/options-from-args.ts
@@ -49,5 +49,9 @@ export const optionsFromArgs = (args: ParsedArgs): Partial<Options> => {
         options.rootMarker = args.rootMarker as any;
     }
 
+    if (args.allowEmptyTags != null) {
+        options.allowEmptyTags = !!args.allowEmptyTags;
+    }
+
     return options;
 };

--- a/src/parse-file.ts
+++ b/src/parse-file.ts
@@ -40,6 +40,10 @@ export default function parseFile(
     const errors: Array<ErrorDetails> = [];
 
     const recordError = (e: ErrorDetails): void => {
+        if (e.code === ErrorCode.emptyMarker && options.allowEmptyTargets) {
+            // We don't error on empty markers if we've been told not to.
+            return;
+        }
         errors.push(e);
     };
 

--- a/src/parse-file.ts
+++ b/src/parse-file.ts
@@ -40,7 +40,7 @@ export default function parseFile(
     const errors: Array<ErrorDetails> = [];
 
     const recordError = (e: ErrorDetails): void => {
-        if (e.code === ErrorCode.emptyMarker && options.allowEmptyTargets) {
+        if (e.code === ErrorCode.emptyMarker && options.allowEmptyTags) {
             // We don't error on empty markers if we've been told not to.
             return;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,11 @@ export type Options = {
      * The name of the marker file that identifies the root of sync-tag paths.
      */
     rootMarker?: string | null | undefined;
+    /**
+     * When false, a tag must contain content to be considered valid;
+     * when true, a tag may be empty.
+     */
+    allowEmptyTargets: boolean;
 };
 
 export type NormalizedFileInfo = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,7 +217,7 @@ export type Options = {
      * When false, a tag must contain content to be considered valid;
      * when true, a tag may be empty.
      */
-    allowEmptyTargets: boolean;
+    allowEmptyTags: boolean;
 };
 
 export type NormalizedFileInfo = {


### PR DESCRIPTION
## Summary:
This adds a new configuration option to allow empty tags, and implements this.

This fixes #1980

## Test plan:
`yarn test`