### PR TITLE
[argparsingfix] Fix issue where implicit args override explicit config

### DIFF
--- a/.changeset/healthy-onions-drop.md
+++ b/.changeset/healthy-onions-drop.md
@@ -1,0 +1,5 @@
+---
+"checksync": major
+---
+
+This fixes an issue where default argument values would override explicit configuration. This was unintentional; only explicitly provided argument values should override configuration. Since some folks may be relying on this broken behaviour, this is a major update. As part of this fix, argument parsing is now handled by yargs instead of minimist

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
         "@types/jest": "^29.5.12",
         "@types/lodash": "^4.17.5",
         "@types/micromatch": "^4.0.7",
-        "@types/minimist": "^1.2.5",
         "@types/node": "^20.14.2",
         "@types/parse-gitignore": "^1.0.2",
+        "@types/yargs": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^7.13.0",
         "@typescript-eslint/parser": "^7.13.0",
         "adler-32": "^1.3.1",
@@ -81,13 +81,13 @@
         "jest-extended": "^4.0.2",
         "lodash": "^4.17.21",
         "micromatch": "^4.0.7",
-        "minimist": "^1.2.8",
         "prettier": "^3.3.2",
         "rollup": "^4.18.0",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-filesize": "^10.0.0",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+        "yargs": "^17.7.2"
     },
     "resolutions": {
         "kind-of": "^6.0.3",

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Integration Tests (see __examples__ folder) should report example checksums_need_updating to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/checksums_need_updating/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/checksums_need_updating/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -10,8 +14,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/checksums_need_updating/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -47,7 +89,13 @@ Make sure you've made the parallel changes in the source file, if necessary (123
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example checksums_need_updating to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/checksums_need_updating/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/checksums_need_updating/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -56,8 +104,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/checksums_need_updating/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -97,7 +183,12 @@ To fix, run: >
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example checksums_need_updating to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/checksums_need_updating/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/checksums_need_updating/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -106,8 +197,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/checksums_need_updating/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/checksums_need_updating/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -194,7 +323,11 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example content_after_start to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/content_after_start/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/content_after_start/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -203,8 +336,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/content_after_start/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -248,7 +419,13 @@ No return tag named 'content_after_start' in '__examples__/content_after_start/a
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example content_after_start to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/content_after_start/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/content_after_start/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -257,8 +434,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/content_after_start/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -301,7 +516,12 @@ To fix, run: >
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example content_after_start to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/content_after_start/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/content_after_start/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -310,8 +530,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/content_after_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/content_after_start/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -413,7 +671,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example correct_checksums to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/correct_checksums/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/correct_checksums/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -422,8 +684,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/correct_checksums/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -443,7 +743,13 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example correct_checksums to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/correct_checksums/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/correct_checksums/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -452,8 +758,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/correct_checksums/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -474,7 +818,12 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example correct_checksums to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/correct_checksums/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/correct_checksums/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -483,8 +832,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/correct_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/correct_checksums/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -508,7 +895,11 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example directory_target to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/directory_target/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/directory_target/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -517,8 +908,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/directory_target/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -544,7 +973,13 @@ No return tag named 'directory_target' in '__examples__/directory_target/a_direc
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example directory_target to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/directory_target/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/directory_target/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -553,8 +988,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/directory_target/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -581,7 +1054,12 @@ No return tag named 'directory_target' in '__examples__/directory_target/a_direc
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example directory_target to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/directory_target/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/directory_target/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -590,8 +1068,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/directory_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/directory_target/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -632,7 +1148,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example duplicate-target to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/duplicate-target/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/duplicate-target/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -641,8 +1161,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/duplicate-target/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -676,7 +1234,13 @@ Make sure you've made the parallel changes in the source file, if necessary (456
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example duplicate-target to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/duplicate-target/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/duplicate-target/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -685,8 +1249,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/duplicate-target/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -721,7 +1323,12 @@ To fix, run: >
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example duplicate-target to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/duplicate-target/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/duplicate-target/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -730,8 +1337,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/duplicate-target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/duplicate-target/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -814,7 +1459,11 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example empty_tag to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/empty_tag/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/empty_tag/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -823,8 +1472,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/empty_tag/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -848,7 +1535,13 @@ Sync-tag 'no_content' has no content
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example empty_tag to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/empty_tag/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/empty_tag/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -857,8 +1550,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/empty_tag/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -883,7 +1614,12 @@ Sync-tag 'no_content' has no content
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example empty_tag to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/empty_tag/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/empty_tag/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -892,8 +1628,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/empty_tag/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/empty_tag/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -927,7 +1701,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example end_with_no_start to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/end_with_no_start/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/end_with_no_start/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -936,8 +1714,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/end_with_no_start/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -960,7 +1776,13 @@ Sync-end for 'end_with_no_start' found, but there was no corresponding sync-star
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example end_with_no_start to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/end_with_no_start/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/end_with_no_start/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -969,8 +1791,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/end_with_no_start/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -994,7 +1854,12 @@ Sync-end for 'end_with_no_start' found, but there was no corresponding sync-star
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example end_with_no_start to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/end_with_no_start/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/end_with_no_start/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1003,8 +1868,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/end_with_no_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/end_with_no_start/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1037,7 +1940,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example excluded to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/excluded/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/excluded/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1046,8 +1953,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/excluded/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1063,7 +2008,13 @@ Error    No matching files"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example excluded to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/excluded/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/excluded/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1072,8 +2023,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/excluded/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1090,7 +2079,12 @@ Error    No matching files"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example excluded to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/excluded/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/excluded/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1099,8 +2093,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/excluded/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/excluded/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1116,7 +2148,11 @@ Error    No matching files"
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example ignore_files_at_different_depths to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/ignore_files_at_different_depths/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/ignore_files_at_different_depths/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1125,8 +2161,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/ignore_files_at_different_depths/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1156,7 +2230,13 @@ Sync-end for 'end_with_no_start' found, but there was no corresponding sync-star
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example ignore_files_at_different_depths to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/ignore_files_at_different_depths/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/ignore_files_at_different_depths/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1165,8 +2245,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/ignore_files_at_different_depths/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1197,7 +2315,12 @@ Sync-end for 'end_with_no_start' found, but there was no corresponding sync-star
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example ignore_files_at_different_depths to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/ignore_files_at_different_depths/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/ignore_files_at_different_depths/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1206,8 +2329,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/ignore_files_at_different_depths/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/ignore_files_at_different_depths/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1247,7 +2408,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_end to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/malformed_end/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/malformed_end/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1256,8 +2421,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/malformed_end/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1288,7 +2491,13 @@ __examples__/malformed_end/malformed_noid.js
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_end to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/malformed_end/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/malformed_end/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1297,8 +2506,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/malformed_end/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1330,7 +2577,12 @@ __examples__/malformed_end/malformed_noid.js
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_end to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/malformed_end/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/malformed_end/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1339,8 +2591,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_end/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/malformed_end/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1397,7 +2687,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_start to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/malformed_start/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/malformed_start/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1406,8 +2700,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/malformed_start/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1444,7 +2776,13 @@ __examples__/malformed_start/malformed_onlytagid.js
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_start to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/malformed_start/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/malformed_start/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1453,8 +2791,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/malformed_start/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1492,7 +2868,12 @@ __examples__/malformed_start/malformed_onlytagid.js
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example malformed_start to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/malformed_start/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/malformed_start/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1501,8 +2882,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/malformed_start/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/malformed_start/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1576,7 +2995,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example missing_target to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/missing_target/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/missing_target/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1585,8 +3008,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/missing_target/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1611,7 +3072,13 @@ No return tag named 'missing_target' in '__examples__/missing_target/missing_tar
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example missing_target to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/missing_target/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/missing_target/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1620,8 +3087,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/missing_target/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1647,7 +3152,12 @@ No return tag named 'missing_target' in '__examples__/missing_target/missing_tar
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example missing_target to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/missing_target/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/missing_target/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1656,8 +3166,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/missing_target/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/missing_target/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1697,7 +3245,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_back_reference to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/no_back_reference/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_back_reference/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1706,8 +3258,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_back_reference/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1731,7 +3321,13 @@ No return tag named 'markerID' in '__examples__/no_back_reference/file2.js'
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_back_reference to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/no_back_reference/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_back_reference/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1740,8 +3336,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_back_reference/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1766,7 +3400,12 @@ No return tag named 'markerID' in '__examples__/no_back_reference/file2.js'
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_back_reference to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/no_back_reference/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_back_reference/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1775,8 +3414,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_back_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_back_reference/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1810,7 +3487,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_checksums to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/no_checksums/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_checksums/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1819,8 +3500,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_checksums/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1849,7 +3568,13 @@ Make sure you've made the parallel changes in the source file, if necessary (No 
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_checksums to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/no_checksums/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_checksums/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1858,8 +3583,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_checksums/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -1892,7 +3655,12 @@ To fix, run: >
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_checksums to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/no_checksums/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_checksums/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1901,8 +3669,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_checksums/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_checksums/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1958,7 +3764,11 @@ Verbose  Discovered paths: [
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_self_reference to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/no_self_reference/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_self_reference/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -1967,8 +3777,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_self_reference/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -1999,7 +3847,13 @@ Make sure you've made the parallel changes in the source file, if necessary (No 
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_self_reference to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/no_self_reference/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_self_reference/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -2008,8 +3862,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_self_reference/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -2038,7 +3930,12 @@ To fix, run: >
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example no_self_reference to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/no_self_reference/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_self_reference/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -2047,8 +3944,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/no_self_reference/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_self_reference/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -2095,7 +4030,11 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example unterminated_marker to match snapshot 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/unterminated_marker/**"]}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/unterminated_marker/**"
+  ]
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -2104,8 +4043,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/unterminated_marker/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
@@ -2132,7 +4109,13 @@ __examples__/unterminated_marker/example_two-b.py
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example unterminated_marker to match snapshot with autofix dryrun 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/unterminated_marker/**"],"autoFix":true,"dryRun":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/unterminated_marker/**"
+  ],
+  "autoFix": true,
+  "dryRun": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -2141,8 +4124,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":true,"json":false,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":true,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/unterminated_marker/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Info     DRY-RUN: Files will not be modified
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
@@ -2170,7 +4191,12 @@ __examples__/unterminated_marker/example_two-b.py
 `;
 
 exports[`Integration Tests (see __examples__ folder) should report example unterminated_marker to match snapshot with json 1`] = `
-"Verbose  Options from arguments: {"includeGlobs":["**/unterminated_marker/**"],"json":true}
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/unterminated_marker/**"
+  ],
+  "json": true
+}
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
 Verbose  Checking ROOT_DIR/.checksyncrc.json...
@@ -2179,8 +4205,46 @@ Verbose  Changing working directory to ROOT_DIR
 Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
 Verbose  Validating configuration
 Verbose  Configuration is valid
-Verbose  Options from config: {"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.","autoFix":false,"comments":["//","#","{/*"],"dryRun":false,"excludeGlobs":["**/excluded/**"],"ignoreFiles":["**/ignore-file.txt"],"json":false}
-Verbose  Combined options with defaults: {"autoFix":false,"json":true,"allowEmptyTags":false,"comments":["//","#","{/*"],"excludeGlobs":["**/excluded/**"],"dryRun":false,"ignoreFiles":["**/ignore-file.txt"],"includeGlobs":["**/unterminated_marker/**"],"$schema":"./src/checksync.schema.json","$comment":"This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."}
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/unterminated_marker/**"
+  ],
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
 Verbose  Ignore files: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"

--- a/src/determine-options.ts
+++ b/src/determine-options.ts
@@ -4,12 +4,12 @@ import defaultOptions from "./default-options";
 import {optionsFromArgs} from "./options-from-args";
 
 import {ILog, Options} from "./types";
-import {ParsedArgs} from "minimist";
+import {Arguments} from "yargs";
 import path from "path";
 import setCwd from "./set-cwd";
 
 export default async function determineOptions(
-    args: ParsedArgs,
+    args: Arguments<any>,
     log: ILog,
 ): Promise<Options> {
     /**
@@ -21,7 +21,14 @@ export default async function determineOptions(
     }
 
     const argsOptions = optionsFromArgs(args);
-    log.verbose(() => `Options from arguments: ${JSON.stringify(argsOptions)}`);
+    log.verbose(
+        () =>
+            `Options from arguments: ${JSON.stringify(
+                argsOptions,
+                undefined,
+                2,
+            )}`,
+    );
 
     const configFilePath: string | null | undefined =
         args.config === false
@@ -54,7 +61,11 @@ export default async function determineOptions(
     log.verbose(() =>
         configFromFile == null
             ? null
-            : `Options from config: ${JSON.stringify(configFromFile)}`,
+            : `Options from config: ${JSON.stringify(
+                  configFromFile,
+                  undefined,
+                  2,
+              )}`,
     );
 
     // We have to now build the options, with args taking precedence over
@@ -68,6 +79,8 @@ export default async function determineOptions(
         () =>
             `Combined options with defaults: ${JSON.stringify(
                 combinedOptions,
+                undefined,
+                2,
             )}`,
     );
 

--- a/src/options-from-args.ts
+++ b/src/options-from-args.ts
@@ -1,10 +1,10 @@
 import {Options} from "./types";
-import {ParsedArgs} from "minimist";
+import {Arguments} from "yargs";
 
 /**
  * Convert arguments to options.
  */
-export const optionsFromArgs = (args: ParsedArgs): Partial<Options> => {
+export const optionsFromArgs = (args: Arguments<any>): Partial<Options> => {
     const options: Partial<Options> = {};
     if (args._ && args._.length > 0) {
         options.includeGlobs = args._;

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -1,0 +1,43 @@
+import yargs from "yargs/yargs";
+import {hideBin} from "yargs/helpers";
+import {ExitCode} from "./exit-codes";
+import exit from "./exit";
+import {ILog} from "./types";
+
+export const parseArgs = (log: ILog) =>
+    yargs(hideBin(process.argv))
+        .boolean([
+            "updateTags",
+            "dryRun",
+            "help",
+            "verbose",
+            "version",
+            "json",
+            "allowEmptyTags",
+        ])
+        .string([
+            "cwd",
+            "comments",
+            "rootMarker",
+            "ignore",
+            "ignoreFiles",
+            "config",
+        ])
+        .alias("comments", ["c"])
+        .alias("dryRun", ["n", "dry-run"])
+        .alias("help", ["h", "?"])
+        .alias("ignore", ["i"])
+        .alias("ignoreFiles", ["ignore-files"])
+        .alias("json", ["j"])
+        .alias("rootMarker", ["m", "root-marker"])
+        .alias("updateTags", ["u", "update-tags"])
+        .alias("allowEmptyTags", ["a", "allow-empty-tags"])
+        .strictOptions()
+        .fail((msg, err, yargs) => {
+            log.error(msg);
+            exit(log, ExitCode.UNKNOWN_ARGS);
+        })
+        .help(false)
+        .version(false)
+        .showHelpOnFail(false)
+        .parse();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2057,11 +2057,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/minimist@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"
-  integrity sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==
-
 "@types/node@*", "@types/node@^20.14.2":
   version "20.14.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.12.tgz#129d7c3a822cb49fc7ff661235f19cfefd422b49"
@@ -2095,6 +2090,13 @@
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.0.0.tgz#453743c5bbf9f1bed61d959baab5b06be029b2d0"
   integrity sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==
+
+"@types/yargs@^17.0.33":
+  version "17.0.33"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.33.tgz#8c32303da83eec050a84b3c7ae7b9f922d13e32d"
+  integrity sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@types/yargs@^17.0.8":
   version "17.0.10"
@@ -5501,7 +5503,7 @@ minimatch@^9.0.4:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
+minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -6883,14 +6885,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^5.1.0, strip-ansi@^6, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^5.1.0, strip-ansi@^6, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7400,16 +7395,7 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7451,7 +7437,7 @@ yargs-parser@^21.1.1:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.3.1:
+yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
## Summary:
It turns out that we were overriding default values and explicit configuration with the default argument values for our boolean flags. This was down to minimist defaulting missing boolean args to `false` instead of not providing them. So, I've done a minimal transition to yargs instead.

In a future release, we can leverage more of yargs features, but for now, I've tried to keep things as similar as possible to previous releases.

However, given that this is a change in behaviour, I'm putting it out as a major release in case anyone was inadvertently relying on the broken processing of args and config.

## Test plan:
`yarn test`

Also, try running with a config where a boolean option is set to true and see that it is respected.