### PR TITLE
[🔥AUDIT🔥] [audit.fixhelpandversionargs] Properly configure yargs for custom help and version

### DIFF
--- a/.changeset/unlucky-brooms-pretend.md
+++ b/.changeset/unlucky-brooms-pretend.md
@@ -1,0 +1,5 @@
+---
+"checksync": patch
+---
+
+Fix --help and --version

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -6,6 +6,8 @@ import {ILog} from "./types";
 
 export const parseArgs = (log: ILog) =>
     yargs(hideBin(process.argv))
+        .help(false)
+        .version(false)
         .boolean([
             "updateTags",
             "dryRun",
@@ -37,7 +39,5 @@ export const parseArgs = (log: ILog) =>
             log.error(msg);
             exit(log, ExitCode.UNKNOWN_ARGS);
         })
-        .help(false)
-        .version(false)
         .showHelpOnFail(false)
         .parse();


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Turns out, if you want to turn off the default handling of `--help` and `--version`, then provide custom handling of these args, you have to do it in that order. 🤦

## Test plan:
`./dev/checksync.dev.js --version`
`./dev/checksync.dev.js --help
`