### PR TITLE
[somewhatabstract/issue2039] Add cache support

### DIFF
--- a/.changeset/puny-eggs-carry.md
+++ b/.changeset/puny-eggs-carry.md
@@ -1,0 +1,5 @@
+---
+"checksync": patch
+---
+
+Add ability to parse markers to a JSON file and then use that file as input to future runs

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn-error.log
 _quokka.js
 *.tsbuildinfo
 .integrationtests/
+cache.json

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -6,7 +6,9 @@ exports[`Integration Tests (see __examples__ folder) Example checksums_need_upda
     "**/checksums_need_updating/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "checksums_need_updating.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -53,27 +55,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "checksums_need_updating.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/checksums_need_updating/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/checksums_need_updating/a.js",
-    "ROOT_DIR/__examples__/checksums_need_updating/b.py",
-    "ROOT_DIR/__examples__/checksums_need_updating/c.jsx"
-]
+Info     Loading cache from ROOT_DIR/checksums_need_updating.json
 Verbose  __examples__/checksums_need_updating/a.js
 File has errors; skipping auto-fix
 Fix      __examples__/checksums_need_updating/a.js:4
@@ -100,7 +88,9 @@ exports[`Integration Tests (see __examples__ folder) Example checksums_need_upda
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
-  ]
+  ],
+  "cachePath": "checksums_need_updating.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -147,26 +137,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "checksums_need_updating.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/checksums_need_updating/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/checksums_need_updating/a.js",
-    "ROOT_DIR/__examples__/checksums_need_updating/b.py",
-    "ROOT_DIR/__examples__/checksums_need_updating/c.jsx"
-]
+Info     Loading cache from ROOT_DIR/checksums_need_updating.json
 Mismatch __examples__/checksums_need_updating/a.js:4
 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'
 Make sure you've made corresponding changes in the source file, if necessary (45678 != 249234014)
@@ -191,7 +167,9 @@ exports[`Integration Tests (see __examples__ folder) Example checksums_need_upda
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "checksums_need_updating.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -238,26 +216,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "checksums_need_updating.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/checksums_need_updating/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/checksums_need_updating/a.js",
-    "ROOT_DIR/__examples__/checksums_need_updating/b.py",
-    "ROOT_DIR/__examples__/checksums_need_updating/c.jsx"
-]
+Info     Loading cache from ROOT_DIR/checksums_need_updating.json
 {
     "version": "0.0.0",
     "launchString": "checksync -u __examples__/checksums_need_updating/a.js __examples__/checksums_need_updating/b.py __examples__/checksums_need_updating/c.jsx",
@@ -328,13 +292,91 @@ Verbose  Discovered paths: [
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example checksums_need_updating should report example checksums_need_updating to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/checksums_need_updating/**"
+  ],
+  "cachePath": "checksums_need_updating.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/checksums_need_updating/**"
+  ],
+  "cachePath": "checksums_need_updating.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/checksums_need_updating/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/checksums_need_updating/a.js",
+    "ROOT_DIR/__examples__/checksums_need_updating/b.py",
+    "ROOT_DIR/__examples__/checksums_need_updating/c.jsx"
+]
+Info     Cache written to ROOT_DIR/checksums_need_updating.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example content_after_start should report example content_after_start to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "content_after_start.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -381,27 +423,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "content_after_start.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/content_after_start/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/content_after_start/a.js",
-    "ROOT_DIR/__examples__/content_after_start/b.py",
-    "ROOT_DIR/__examples__/content_after_start/c.js"
-]
+Info     Loading cache from ROOT_DIR/content_after_start.json
 Verbose  __examples__/content_after_start/a.js
 File has errors; skipping auto-fix
 Fix      __examples__/content_after_start/a.js:3
@@ -431,7 +459,9 @@ exports[`Integration Tests (see __examples__ folder) Example content_after_start
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/content_after_start/**"
-  ]
+  ],
+  "cachePath": "content_after_start.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -478,26 +508,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "content_after_start.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/content_after_start/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/content_after_start/a.js",
-    "ROOT_DIR/__examples__/content_after_start/b.py",
-    "ROOT_DIR/__examples__/content_after_start/c.js"
-]
+Info     Loading cache from ROOT_DIR/content_after_start.json
 Mismatch __examples__/content_after_start/a.js:3
 Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/b.py:3'
 Make sure you've made corresponding changes in the source file, if necessary (No checksum != 249234014)
@@ -530,7 +546,9 @@ exports[`Integration Tests (see __examples__ folder) Example content_after_start
   "includeGlobs": [
     "**/content_after_start/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "content_after_start.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -577,26 +595,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "content_after_start.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/content_after_start/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/content_after_start/a.js",
-    "ROOT_DIR/__examples__/content_after_start/b.py",
-    "ROOT_DIR/__examples__/content_after_start/c.js"
-]
+Info     Loading cache from ROOT_DIR/content_after_start.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -682,13 +686,91 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example content_after_start should report example content_after_start to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/content_after_start/**"
+  ],
+  "cachePath": "content_after_start.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/content_after_start/**"
+  ],
+  "cachePath": "content_after_start.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/content_after_start/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/content_after_start/a.js",
+    "ROOT_DIR/__examples__/content_after_start/b.py",
+    "ROOT_DIR/__examples__/content_after_start/c.js"
+]
+Info     Cache written to ROOT_DIR/content_after_start.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example correct_checksums should report example correct_checksums to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "correct_checksums.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -735,27 +817,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "correct_checksums.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/correct_checksums/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/correct_checksums/a.js",
-    "ROOT_DIR/__examples__/correct_checksums/b.py",
-    "ROOT_DIR/__examples__/correct_checksums/c.jsx"
-]
+Info     Loading cache from ROOT_DIR/correct_checksums.json
 🎉  Everything is in sync!"
 `;
 
@@ -763,7 +831,9 @@ exports[`Integration Tests (see __examples__ folder) Example correct_checksums s
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/correct_checksums/**"
-  ]
+  ],
+  "cachePath": "correct_checksums.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -810,26 +880,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "correct_checksums.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/correct_checksums/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/correct_checksums/a.js",
-    "ROOT_DIR/__examples__/correct_checksums/b.py",
-    "ROOT_DIR/__examples__/correct_checksums/c.jsx"
-]
+Info     Loading cache from ROOT_DIR/correct_checksums.json
 🎉  Everything is in sync!"
 `;
 
@@ -838,7 +894,9 @@ exports[`Integration Tests (see __examples__ folder) Example correct_checksums s
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "correct_checksums.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -885,8 +943,74 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "correct_checksums.json",
+  "cacheMode": "read",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Info     Loading cache from ROOT_DIR/correct_checksums.json
+{
+    "version": "0.0.0",
+    "launchString": "checksync -u ",
+    "files": {}
+}"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example correct_checksums should report example correct_checksums to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/correct_checksums/**"
+  ],
+  "cachePath": "correct_checksums.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/correct_checksums/**"
+  ],
+  "cachePath": "correct_checksums.json",
+  "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -905,11 +1029,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/correct_checksums/b.py",
     "ROOT_DIR/__examples__/correct_checksums/c.jsx"
 ]
-{
-    "version": "0.0.0",
-    "launchString": "checksync -u ",
-    "files": {}
-}"
+Info     Cache written to ROOT_DIR/correct_checksums.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example directory_target should report example directory_target to match snapshot for scenario autofix 1`] = `
@@ -918,7 +1038,9 @@ exports[`Integration Tests (see __examples__ folder) Example directory_target sh
     "**/directory_target/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "directory_target.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -965,26 +1087,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/directory_target/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "directory_target.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/directory_target/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/directory_target/a_directory/somefile.js",
-    "ROOT_DIR/__examples__/directory_target/example.js"
-]
+Info     Loading cache from ROOT_DIR/directory_target.json
 Error    __examples__/directory_target/example.js:3
 Sync-start for 'directory_target' points to '__examples__/directory_target/a_directory', which does not exist or is a directory
 Error    __examples__/directory_target/example.js:3
@@ -999,7 +1108,9 @@ exports[`Integration Tests (see __examples__ folder) Example directory_target sh
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/directory_target/**"
-  ]
+  ],
+  "cachePath": "directory_target.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1046,25 +1157,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/directory_target/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "directory_target.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/directory_target/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/directory_target/a_directory/somefile.js",
-    "ROOT_DIR/__examples__/directory_target/example.js"
-]
+Info     Loading cache from ROOT_DIR/directory_target.json
 Error    __examples__/directory_target/example.js:3
 Sync-start for 'directory_target' points to '__examples__/directory_target/a_directory', which does not exist or is a directory
 Error    __examples__/directory_target/example.js:3
@@ -1080,7 +1178,9 @@ exports[`Integration Tests (see __examples__ folder) Example directory_target sh
   "includeGlobs": [
     "**/directory_target/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "directory_target.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1127,25 +1227,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/directory_target/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "directory_target.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/directory_target/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/directory_target/a_directory/somefile.js",
-    "ROOT_DIR/__examples__/directory_target/example.js"
-]
+Info     Loading cache from ROOT_DIR/directory_target.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -1171,13 +1258,90 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example directory_target should report example directory_target to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/directory_target/**"
+  ],
+  "cachePath": "directory_target.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/directory_target/**"
+  ],
+  "cachePath": "directory_target.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/directory_target/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/directory_target/a_directory/somefile.js",
+    "ROOT_DIR/__examples__/directory_target/example.js"
+]
+Info     Cache written to ROOT_DIR/directory_target.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example duplicate-target should report example duplicate-target to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "duplicate_target.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1224,26 +1388,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "duplicate_target.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/duplicate-target/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/duplicate-target/a.js",
-    "ROOT_DIR/__examples__/duplicate-target/b.py"
-]
+Info     Loading cache from ROOT_DIR/duplicate_target.json
 Verbose  __examples__/duplicate-target/a.js
 File has errors; skipping auto-fix
 Fix      __examples__/duplicate-target/a.js:4
@@ -1266,7 +1417,9 @@ exports[`Integration Tests (see __examples__ folder) Example duplicate-target sh
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/duplicate-target/**"
-  ]
+  ],
+  "cachePath": "duplicate_target.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1313,25 +1466,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "duplicate_target.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/duplicate-target/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/duplicate-target/a.js",
-    "ROOT_DIR/__examples__/duplicate-target/b.py"
-]
+Info     Loading cache from ROOT_DIR/duplicate_target.json
 Warning  __examples__/duplicate-target/a.js:5
 Duplicate target for sync-tag 'update_me'
 Mismatch __examples__/duplicate-target/a.js:4
@@ -1355,7 +1495,9 @@ exports[`Integration Tests (see __examples__ folder) Example duplicate-target sh
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "duplicate_target.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1402,25 +1544,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "duplicate_target.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/duplicate-target/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/duplicate-target/a.js",
-    "ROOT_DIR/__examples__/duplicate-target/b.py"
-]
+Info     Loading cache from ROOT_DIR/duplicate_target.json
 {
     "version": "0.0.0",
     "launchString": "checksync -u __examples__/duplicate-target/a.js __examples__/duplicate-target/b.py",
@@ -1488,13 +1617,90 @@ Verbose  Discovered paths: [
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example duplicate-target should report example duplicate-target to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/duplicate-target/**"
+  ],
+  "cachePath": "duplicate_target.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/duplicate-target/**"
+  ],
+  "cachePath": "duplicate_target.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/duplicate-target/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/duplicate-target/a.js",
+    "ROOT_DIR/__examples__/duplicate-target/b.py"
+]
+Info     Cache written to ROOT_DIR/duplicate_target.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example empty_tag should report example empty_tag to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "empty_tag.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1541,26 +1747,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "empty_tag.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/empty_tag/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/empty_tag/a.js",
-    "ROOT_DIR/__examples__/empty_tag/b.js"
-]
+Info     Loading cache from ROOT_DIR/empty_tag.json
 Error    __examples__/empty_tag/a.js:2
 Sync-tag 'no_content' has no content
 
@@ -1573,7 +1766,9 @@ exports[`Integration Tests (see __examples__ folder) Example empty_tag should re
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/empty_tag/**"
-  ]
+  ],
+  "cachePath": "empty_tag.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1620,25 +1815,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "empty_tag.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/empty_tag/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/empty_tag/a.js",
-    "ROOT_DIR/__examples__/empty_tag/b.js"
-]
+Info     Loading cache from ROOT_DIR/empty_tag.json
 Error    __examples__/empty_tag/a.js:2
 Sync-tag 'no_content' has no content
 
@@ -1652,7 +1834,9 @@ exports[`Integration Tests (see __examples__ folder) Example empty_tag should re
   "includeGlobs": [
     "**/empty_tag/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "empty_tag.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1699,25 +1883,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "empty_tag.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/empty_tag/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/empty_tag/a.js",
-    "ROOT_DIR/__examples__/empty_tag/b.js"
-]
+Info     Loading cache from ROOT_DIR/empty_tag.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -1736,13 +1907,90 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example empty_tag should report example empty_tag to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/empty_tag/**"
+  ],
+  "cachePath": "empty_tag.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/empty_tag/**"
+  ],
+  "cachePath": "empty_tag.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/empty_tag/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/empty_tag/a.js",
+    "ROOT_DIR/__examples__/empty_tag/b.js"
+]
+Info     Cache written to ROOT_DIR/empty_tag.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example end_with_no_start should report example end_with_no_start to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "end_with_no_start.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1789,25 +2037,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "end_with_no_start.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/end_with_no_start/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/end_with_no_start/example.js"
-]
+Info     Loading cache from ROOT_DIR/end_with_no_start.json
 Error    __examples__/end_with_no_start/example.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
@@ -1820,7 +2056,9 @@ exports[`Integration Tests (see __examples__ folder) Example end_with_no_start s
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/end_with_no_start/**"
-  ]
+  ],
+  "cachePath": "end_with_no_start.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1867,24 +2105,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "end_with_no_start.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/end_with_no_start/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/end_with_no_start/example.js"
-]
+Info     Loading cache from ROOT_DIR/end_with_no_start.json
 Error    __examples__/end_with_no_start/example.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
@@ -1898,7 +2124,9 @@ exports[`Integration Tests (see __examples__ folder) Example end_with_no_start s
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "end_with_no_start.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -1945,24 +2173,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "end_with_no_start.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/end_with_no_start/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/end_with_no_start/example.js"
-]
+Info     Loading cache from ROOT_DIR/end_with_no_start.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -1981,13 +2197,89 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example end_with_no_start should report example end_with_no_start to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/end_with_no_start/**"
+  ],
+  "cachePath": "end_with_no_start.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/end_with_no_start/**"
+  ],
+  "cachePath": "end_with_no_start.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/end_with_no_start/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/end_with_no_start/example.js"
+]
+Info     Cache written to ROOT_DIR/end_with_no_start.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example excluded should report example excluded to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/excluded/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "excluded.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2034,31 +2326,23 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/excluded/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "excluded.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/excluded/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: []
-Error    No matching files"
+Info     Loading cache from ROOT_DIR/excluded.json
+Error    Unable to load cache"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example excluded should report example excluded to match snapshot for scenario check-only 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/excluded/**"
-  ]
+  ],
+  "cachePath": "excluded.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2105,23 +2389,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/excluded/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "excluded.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/excluded/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: []
-Error    No matching files"
+Info     Loading cache from ROOT_DIR/excluded.json
+Error    Unable to load cache"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example excluded should report example excluded to match snapshot for scenario json-check-only 1`] = `
@@ -2129,7 +2403,9 @@ exports[`Integration Tests (see __examples__ folder) Example excluded should rep
   "includeGlobs": [
     "**/excluded/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "excluded.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2176,8 +2452,70 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/excluded/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "excluded.json",
+  "cacheMode": "read",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Info     Loading cache from ROOT_DIR/excluded.json
+Error    Unable to load cache"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example excluded should report example excluded to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/excluded/**"
+  ],
+  "cachePath": "excluded.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/excluded/**"
+  ],
+  "cachePath": "excluded.json",
+  "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2201,7 +2539,9 @@ exports[`Integration Tests (see __examples__ folder) Example ignore_files_at_dif
     "**/ignore_files_at_different_depths/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "ignore_files_at_different_depths.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2248,32 +2588,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "ignore_files_at_different_depths.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/ignore_files_at_different_depths/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/ignore-file.txt by __examples__/ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/ignorethesewhennotinsome/bad-sync-tags-never-parsed.js by __examples__/ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/alsoignorethis.txt by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignore-file.txt by __examples__/ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignore-file.txt by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by __examples__/ignore_files_at_different_depths/ignore-file.txt
-Verbose  UNIGNORED: __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js"
-]
+Info     Loading cache from ROOT_DIR/ignore_files_at_different_depths.json
 Error    __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
@@ -2286,7 +2607,9 @@ exports[`Integration Tests (see __examples__ folder) Example ignore_files_at_dif
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
-  ]
+  ],
+  "cachePath": "ignore_files_at_different_depths.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2333,31 +2656,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "ignore_files_at_different_depths.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/ignore_files_at_different_depths/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/ignore-file.txt by __examples__/ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/ignorethesewhennotinsome/bad-sync-tags-never-parsed.js by __examples__/ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/alsoignorethis.txt by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignore-file.txt by __examples__/ignore_files_at_different_depths/ignore-file.txt
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignore-file.txt by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  IGNORED  : __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by __examples__/ignore_files_at_different_depths/ignore-file.txt
-Verbose  UNIGNORED: __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js by __examples__/ignore_files_at_different_depths/some/ignore-file.txt
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js"
-]
+Info     Loading cache from ROOT_DIR/ignore_files_at_different_depths.json
 Error    __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
@@ -2371,7 +2675,9 @@ exports[`Integration Tests (see __examples__ folder) Example ignore_files_at_dif
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "ignore_files_at_different_depths.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2418,8 +2724,85 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "ignore_files_at_different_depths.json",
+  "cacheMode": "read",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Info     Loading cache from ROOT_DIR/ignore_files_at_different_depths.json
+Error    🛑  Unfixable errors found. Fix the errors and try again.
+{
+    "version": "0.0.0",
+    "launchString": "checksync -u ",
+    "files": {
+        "__examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js": [
+            {
+                "reason": "Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start",
+                "location": {
+                    "line": 5
+                },
+                "code": "end-tag-without-start-tag"
+            }
+        ]
+    }
+}"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example ignore_files_at_different_depths should report example ignore_files_at_different_depths to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/ignore_files_at_different_depths/**"
+  ],
+  "cachePath": "ignore_files_at_different_depths.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/ignore_files_at_different_depths/**"
+  ],
+  "cachePath": "ignore_files_at_different_depths.json",
+  "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2443,22 +2826,7 @@ Verbose  UNIGNORED: __examples__/ignore_files_at_different_depths/some/ignorethe
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js"
 ]
-Error    🛑  Unfixable errors found. Fix the errors and try again.
-{
-    "version": "0.0.0",
-    "launchString": "checksync -u ",
-    "files": {
-        "__examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js": [
-            {
-                "reason": "Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start",
-                "location": {
-                    "line": 5
-                },
-                "code": "end-tag-without-start-tag"
-            }
-        ]
-    }
-}"
+Info     Cache written to ROOT_DIR/ignore_files_at_different_depths.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example malformed_end should report example malformed_end to match snapshot for scenario autofix 1`] = `
@@ -2467,7 +2835,9 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_end shoul
     "**/malformed_end/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "malformed_end.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2514,26 +2884,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_end/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "malformed_end.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/malformed_end/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/malformed_end/malformed_badid.js",
-    "ROOT_DIR/__examples__/malformed_end/malformed_noid.js"
-]
+Info     Loading cache from ROOT_DIR/malformed_end.json
 Error    __examples__/malformed_end/malformed_badid.js:7
 Malformed sync-end: format should be 'sync-end:<label>'
 Error    __examples__/malformed_end/malformed_badid.js:4
@@ -2553,7 +2910,9 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_end shoul
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/malformed_end/**"
-  ]
+  ],
+  "cachePath": "malformed_end.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2600,25 +2959,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_end/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "malformed_end.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/malformed_end/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/malformed_end/malformed_badid.js",
-    "ROOT_DIR/__examples__/malformed_end/malformed_noid.js"
-]
+Info     Loading cache from ROOT_DIR/malformed_end.json
 Error    __examples__/malformed_end/malformed_badid.js:7
 Malformed sync-end: format should be 'sync-end:<label>'
 Error    __examples__/malformed_end/malformed_badid.js:4
@@ -2639,7 +2985,9 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_end shoul
   "includeGlobs": [
     "**/malformed_end/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "malformed_end.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2686,25 +3034,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_end/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "malformed_end.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/malformed_end/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/malformed_end/malformed_badid.js",
-    "ROOT_DIR/__examples__/malformed_end/malformed_noid.js"
-]
+Info     Loading cache from ROOT_DIR/malformed_end.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -2746,13 +3081,90 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example malformed_end should report example malformed_end to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/malformed_end/**"
+  ],
+  "cachePath": "malformed_end.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/malformed_end/**"
+  ],
+  "cachePath": "malformed_end.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/malformed_end/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/malformed_end/malformed_badid.js",
+    "ROOT_DIR/__examples__/malformed_end/malformed_noid.js"
+]
+Info     Cache written to ROOT_DIR/malformed_end.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example malformed_start should report example malformed_start to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "malformed_start.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2799,27 +3211,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "malformed_start.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/malformed_start/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/malformed_start/malformed_badchecksum.js",
-    "ROOT_DIR/__examples__/malformed_start/malformed_badid.js",
-    "ROOT_DIR/__examples__/malformed_start/malformed_onlytagid.js"
-]
+Info     Loading cache from ROOT_DIR/malformed_start.json
 Error    __examples__/malformed_start/malformed_badchecksum.js:4
 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
 Error    __examples__/malformed_start/malformed_badchecksum.js:7
@@ -2844,7 +3242,9 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_start sho
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/malformed_start/**"
-  ]
+  ],
+  "cachePath": "malformed_start.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2891,26 +3291,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "malformed_start.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/malformed_start/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/malformed_start/malformed_badchecksum.js",
-    "ROOT_DIR/__examples__/malformed_start/malformed_badid.js",
-    "ROOT_DIR/__examples__/malformed_start/malformed_onlytagid.js"
-]
+Info     Loading cache from ROOT_DIR/malformed_start.json
 Error    __examples__/malformed_start/malformed_badchecksum.js:4
 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
 Error    __examples__/malformed_start/malformed_badchecksum.js:7
@@ -2936,7 +3322,9 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_start sho
   "includeGlobs": [
     "**/malformed_start/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "malformed_start.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -2983,26 +3371,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "malformed_start.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/malformed_start/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/malformed_start/malformed_badchecksum.js",
-    "ROOT_DIR/__examples__/malformed_start/malformed_badid.js",
-    "ROOT_DIR/__examples__/malformed_start/malformed_onlytagid.js"
-]
+Info     Loading cache from ROOT_DIR/malformed_start.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -3060,13 +3434,91 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example malformed_start should report example malformed_start to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/malformed_start/**"
+  ],
+  "cachePath": "malformed_start.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/malformed_start/**"
+  ],
+  "cachePath": "malformed_start.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/malformed_start/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/malformed_start/malformed_badchecksum.js",
+    "ROOT_DIR/__examples__/malformed_start/malformed_badid.js",
+    "ROOT_DIR/__examples__/malformed_start/malformed_onlytagid.js"
+]
+Info     Cache written to ROOT_DIR/malformed_start.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example missing_target should report example missing_target to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "missing_target.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3113,25 +3565,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "missing_target.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/missing_target/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/missing_target/example.js"
-]
+Info     Loading cache from ROOT_DIR/missing_target.json
 Error    __examples__/missing_target/example.js:3
 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
 Error    __examples__/missing_target/example.js:3
@@ -3146,7 +3586,9 @@ exports[`Integration Tests (see __examples__ folder) Example missing_target shou
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/missing_target/**"
-  ]
+  ],
+  "cachePath": "missing_target.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3193,24 +3635,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "missing_target.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/missing_target/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/missing_target/example.js"
-]
+Info     Loading cache from ROOT_DIR/missing_target.json
 Error    __examples__/missing_target/example.js:3
 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
 Error    __examples__/missing_target/example.js:3
@@ -3226,7 +3656,9 @@ exports[`Integration Tests (see __examples__ folder) Example missing_target shou
   "includeGlobs": [
     "**/missing_target/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "missing_target.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3273,24 +3705,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "missing_target.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/missing_target/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/missing_target/example.js"
-]
+Info     Loading cache from ROOT_DIR/missing_target.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -3316,13 +3736,89 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example missing_target should report example missing_target to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/missing_target/**"
+  ],
+  "cachePath": "missing_target.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/missing_target/**"
+  ],
+  "cachePath": "missing_target.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/missing_target/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/missing_target/example.js"
+]
+Info     Cache written to ROOT_DIR/missing_target.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example no_back_reference should report example no_back_reference to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "no_back_reference.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3369,26 +3865,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "no_back_reference.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/no_back_reference/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/no_back_reference/file1.js",
-    "ROOT_DIR/__examples__/no_back_reference/file2.js"
-]
+Info     Loading cache from ROOT_DIR/no_back_reference.json
 Error    __examples__/no_back_reference/file1.js:1
 No return tag named 'markerID' in '__examples__/no_back_reference/file2.js'
 
@@ -3401,7 +3884,9 @@ exports[`Integration Tests (see __examples__ folder) Example no_back_reference s
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/no_back_reference/**"
-  ]
+  ],
+  "cachePath": "no_back_reference.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3448,25 +3933,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "no_back_reference.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/no_back_reference/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/no_back_reference/file1.js",
-    "ROOT_DIR/__examples__/no_back_reference/file2.js"
-]
+Info     Loading cache from ROOT_DIR/no_back_reference.json
 Error    __examples__/no_back_reference/file1.js:1
 No return tag named 'markerID' in '__examples__/no_back_reference/file2.js'
 
@@ -3480,7 +3952,9 @@ exports[`Integration Tests (see __examples__ folder) Example no_back_reference s
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "no_back_reference.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3527,25 +4001,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "no_back_reference.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/no_back_reference/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/no_back_reference/file1.js",
-    "ROOT_DIR/__examples__/no_back_reference/file2.js"
-]
+Info     Loading cache from ROOT_DIR/no_back_reference.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -3564,13 +4025,90 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example no_back_reference should report example no_back_reference to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_back_reference/**"
+  ],
+  "cachePath": "no_back_reference.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_back_reference/**"
+  ],
+  "cachePath": "no_back_reference.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/no_back_reference/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/no_back_reference/file1.js",
+    "ROOT_DIR/__examples__/no_back_reference/file2.js"
+]
+Info     Cache written to ROOT_DIR/no_back_reference.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example no_checksums should report example no_checksums to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "no_checksums.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3617,26 +4155,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "no_checksums.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/no_checksums/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/no_checksums/example_one-a.js",
-    "ROOT_DIR/__examples__/no_checksums/example_one-b.py"
-]
+Info     Loading cache from ROOT_DIR/no_checksums.json
 Verbose  __examples__/no_checksums/example_one-a.js
 File has errors; skipping auto-fix
 Fix      __examples__/no_checksums/example_one-a.js:3
@@ -3657,7 +4182,9 @@ exports[`Integration Tests (see __examples__ folder) Example no_checksums should
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/no_checksums/**"
-  ]
+  ],
+  "cachePath": "no_checksums.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3704,25 +4231,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "no_checksums.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/no_checksums/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/no_checksums/example_one-a.js",
-    "ROOT_DIR/__examples__/no_checksums/example_one-b.py"
-]
+Info     Loading cache from ROOT_DIR/no_checksums.json
 Mismatch __examples__/no_checksums/example_one-a.js:3
 Looks like you changed the target content for sync-tag 'example_one' in '__examples__/no_checksums/example_one-b.py:3'
 Make sure you've made corresponding changes in the source file, if necessary (No checksum != 249234014)
@@ -3741,7 +4255,9 @@ exports[`Integration Tests (see __examples__ folder) Example no_checksums should
   "includeGlobs": [
     "**/no_checksums/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "no_checksums.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3788,25 +4304,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "no_checksums.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/no_checksums/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/no_checksums/example_one-a.js",
-    "ROOT_DIR/__examples__/no_checksums/example_one-b.py"
-]
+Info     Loading cache from ROOT_DIR/no_checksums.json
 {
     "version": "0.0.0",
     "launchString": "checksync -u __examples__/no_checksums/example_one-a.js __examples__/no_checksums/example_one-b.py",
@@ -3847,13 +4350,90 @@ Verbose  Discovered paths: [
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example no_checksums should report example no_checksums to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_checksums/**"
+  ],
+  "cachePath": "no_checksums.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_checksums/**"
+  ],
+  "cachePath": "no_checksums.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/no_checksums/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/no_checksums/example_one-a.js",
+    "ROOT_DIR/__examples__/no_checksums/example_one-b.py"
+]
+Info     Cache written to ROOT_DIR/no_checksums.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example no_self_reference should report example no_self_reference to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "no_self_reference.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3900,25 +4480,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "no_self_reference.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/no_self_reference/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/no_self_reference/example.js"
-]
+Info     Loading cache from ROOT_DIR/no_self_reference.json
 Error    __examples__/no_self_reference/example.js:3
 Sync-tag 'example_three' cannot target itself
 
@@ -3936,7 +4504,9 @@ exports[`Integration Tests (see __examples__ folder) Example no_self_reference s
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/no_self_reference/**"
-  ]
+  ],
+  "cachePath": "no_self_reference.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -3983,24 +4553,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "no_self_reference.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/no_self_reference/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/no_self_reference/example.js"
-]
+Info     Loading cache from ROOT_DIR/no_self_reference.json
 Error    __examples__/no_self_reference/example.js:3
 Sync-tag 'example_three' cannot target itself
 Mismatch __examples__/no_self_reference/example.js:3
@@ -4022,7 +4580,9 @@ exports[`Integration Tests (see __examples__ folder) Example no_self_reference s
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "no_self_reference.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4069,24 +4629,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "no_self_reference.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/no_self_reference/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/no_self_reference/example.js"
-]
+Info     Loading cache from ROOT_DIR/no_self_reference.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -4119,13 +4667,89 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example no_self_reference should report example no_self_reference to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/no_self_reference/**"
+  ],
+  "cachePath": "no_self_reference.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/no_self_reference/**"
+  ],
+  "cachePath": "no_self_reference.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/no_self_reference/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/no_self_reference/example.js"
+]
+Info     Cache written to ROOT_DIR/no_self_reference.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example remote_tags_broken should report example remote_tags_broken to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "remote_tags_broken.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4172,25 +4796,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "remote_tags_broken.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/remote_tags_broken/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/remote_tags_broken/example.jsx"
-]
+Info     Loading cache from ROOT_DIR/remote_tags_broken.json
 Verbose  __examples__/remote_tags_broken/example.jsx
 File has errors; skipping auto-fix
 Fix      __examples__/remote_tags_broken/example.jsx:3
@@ -4207,7 +4819,9 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_broken 
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
-  ]
+  ],
+  "cachePath": "remote_tags_broken.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4254,24 +4868,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "remote_tags_broken.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/remote_tags_broken/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/remote_tags_broken/example.jsx"
-]
+Info     Loading cache from ROOT_DIR/remote_tags_broken.json
 Mismatch __examples__/remote_tags_broken/example.jsx:3
 Looks like you changed the content of sync-tag 'remote_target_self_hash' or the path of the file that contains the tag
 Make sure you've made corresponding changes at https://github.com/somewhatabstract/checksync/blob/b9433f22ed9cfdf6c79edfd7254670ff53f82f7c/__examples__/remote_tags_match/example.jsx#L3, if necessary (840225308 != 1603869099)
@@ -4287,7 +4889,9 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_broken 
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "remote_tags_broken.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4334,24 +4938,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "remote_tags_broken.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/remote_tags_broken/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/remote_tags_broken/example.jsx"
-]
+Info     Loading cache from ROOT_DIR/remote_tags_broken.json
 {
     "version": "0.0.0",
     "launchString": "checksync -u __examples__/remote_tags_broken/example.jsx",
@@ -4376,13 +4968,89 @@ Verbose  Discovered paths: [
 }"
 `;
 
+exports[`Integration Tests (see __examples__ folder) Example remote_tags_broken should report example remote_tags_broken to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/remote_tags_broken/**"
+  ],
+  "cachePath": "remote_tags_broken.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/remote_tags_broken/**"
+  ],
+  "cachePath": "remote_tags_broken.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/remote_tags_broken/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/remote_tags_broken/example.jsx"
+]
+Info     Cache written to ROOT_DIR/remote_tags_broken.json"
+`;
+
 exports[`Integration Tests (see __examples__ folder) Example remote_tags_match should report example remote_tags_match to match snapshot for scenario autofix 1`] = `
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "remote_tags_match.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4429,25 +5097,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "remote_tags_match.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/remote_tags_match/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/remote_tags_match/example.jsx"
-]
+Info     Loading cache from ROOT_DIR/remote_tags_match.json
 🎉  Everything is in sync!"
 `;
 
@@ -4455,7 +5111,9 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_match s
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/remote_tags_match/**"
-  ]
+  ],
+  "cachePath": "remote_tags_match.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4502,24 +5160,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "remote_tags_match.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/remote_tags_match/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/remote_tags_match/example.jsx"
-]
+Info     Loading cache from ROOT_DIR/remote_tags_match.json
 🎉  Everything is in sync!"
 `;
 
@@ -4528,7 +5174,9 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_match s
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "remote_tags_match.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4575,8 +5223,74 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "remote_tags_match.json",
+  "cacheMode": "read",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Info     Loading cache from ROOT_DIR/remote_tags_match.json
+{
+    "version": "0.0.0",
+    "launchString": "checksync -u ",
+    "files": {}
+}"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example remote_tags_match should report example remote_tags_match to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/remote_tags_match/**"
+  ],
+  "cachePath": "remote_tags_match.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/remote_tags_match/**"
+  ],
+  "cachePath": "remote_tags_match.json",
+  "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -4593,11 +5307,7 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/remote_tags_match/example.jsx"
 ]
-{
-    "version": "0.0.0",
-    "launchString": "checksync -u ",
-    "files": {}
-}"
+Info     Cache written to ROOT_DIR/remote_tags_match.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example unterminated_marker should report example unterminated_marker to match snapshot for scenario autofix 1`] = `
@@ -4606,7 +5316,9 @@ exports[`Integration Tests (see __examples__ folder) Example unterminated_marker
     "**/unterminated_marker/**"
   ],
   "autoFix": true,
-  "dryRun": true
+  "dryRun": true,
+  "cachePath": "unterminated_marker.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4653,26 +5365,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "unterminated_marker.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/unterminated_marker/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/unterminated_marker/example_two-a.js",
-    "ROOT_DIR/__examples__/unterminated_marker/example_two-b.py"
-]
+Info     Loading cache from ROOT_DIR/unterminated_marker.json
 Error    __examples__/unterminated_marker/example_two-a.js:3
 No return tag named 'example_two' in '__examples__/unterminated_marker/example_two-b.py'
 Error    __examples__/unterminated_marker/example_two-b.py:3
@@ -4688,7 +5387,9 @@ exports[`Integration Tests (see __examples__ folder) Example unterminated_marker
 "Verbose  Options from arguments: {
   "includeGlobs": [
     "**/unterminated_marker/**"
-  ]
+  ],
+  "cachePath": "unterminated_marker.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4735,25 +5436,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "unterminated_marker.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/unterminated_marker/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/unterminated_marker/example_two-a.js",
-    "ROOT_DIR/__examples__/unterminated_marker/example_two-b.py"
-]
+Info     Loading cache from ROOT_DIR/unterminated_marker.json
 Error    __examples__/unterminated_marker/example_two-a.js:3
 No return tag named 'example_two' in '__examples__/unterminated_marker/example_two-b.py'
 Error    __examples__/unterminated_marker/example_two-b.py:3
@@ -4770,7 +5458,9 @@ exports[`Integration Tests (see __examples__ folder) Example unterminated_marker
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
-  "json": true
+  "json": true,
+  "cachePath": "unterminated_marker.json",
+  "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4817,25 +5507,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
-  "cachePath": "cache.json",
-  "cacheMode": "ignore",
+  "cachePath": "unterminated_marker.json",
+  "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/unterminated_marker/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/unterminated_marker/example_two-a.js",
-    "ROOT_DIR/__examples__/unterminated_marker/example_two-b.py"
-]
+Info     Loading cache from ROOT_DIR/unterminated_marker.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -4861,4 +5538,79 @@ Error    🛑  Unfixable errors found. Fix the errors and try again.
         ]
     }
 }"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example unterminated_marker should report example unterminated_marker to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/unterminated_marker/**"
+  ],
+  "cachePath": "unterminated_marker.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/unterminated_marker/**"
+  ],
+  "cachePath": "unterminated_marker.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/unterminated_marker/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/unterminated_marker/example_two-a.js",
+    "ROOT_DIR/__examples__/unterminated_marker/example_two-b.py"
+]
+Info     Cache written to ROOT_DIR/unterminated_marker.json"
 `;

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -53,6 +53,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -145,6 +147,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -234,6 +238,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -375,6 +381,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -470,6 +478,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -567,6 +577,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -723,6 +735,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -796,6 +810,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -869,6 +885,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -947,6 +965,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/directory_target/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1026,6 +1046,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/directory_target/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1105,6 +1127,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/directory_target/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1200,6 +1224,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1287,6 +1313,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1374,6 +1402,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1511,6 +1541,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1588,6 +1620,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1665,6 +1699,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1753,6 +1789,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1829,6 +1867,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1905,6 +1945,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -1992,6 +2034,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/excluded/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2061,6 +2105,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/excluded/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2130,6 +2176,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/excluded/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2200,6 +2248,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2283,6 +2333,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2366,6 +2418,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2460,6 +2514,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_end/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2544,6 +2600,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_end/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2628,6 +2686,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_end/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2739,6 +2799,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2829,6 +2891,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -2919,6 +2983,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3047,6 +3113,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3125,6 +3193,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3203,6 +3273,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3297,6 +3369,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3374,6 +3448,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3451,6 +3527,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3539,6 +3617,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3624,6 +3704,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3706,6 +3788,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3816,6 +3900,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3897,6 +3983,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -3981,6 +4069,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -4082,6 +4172,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -4162,6 +4254,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -4240,6 +4334,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -4333,6 +4429,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -4404,6 +4502,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -4475,6 +4575,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -4551,6 +4653,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -4631,6 +4735,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
@@ -4711,6 +4817,8 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
+  "cachePath": "cache.json",
+  "cacheMode": "ignore",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Integration Tests (see __examples__ folder) Example checksums_need_upda
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "checksums_need_updating.json",
+  "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -55,13 +55,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
-  "cachePath": "checksums_need_updating.json",
+  "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/checksums_need_updating.json
+Info     Loading cache from ROOT_DIR/.integrationtests/checksums_need_updating.json
 Verbose  __examples__/checksums_need_updating/a.js
 File has errors; skipping auto-fix
 Fix      __examples__/checksums_need_updating/a.js:4
@@ -89,7 +89,7 @@ exports[`Integration Tests (see __examples__ folder) Example checksums_need_upda
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
-  "cachePath": "checksums_need_updating.json",
+  "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -137,12 +137,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
-  "cachePath": "checksums_need_updating.json",
+  "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/checksums_need_updating.json
+Info     Loading cache from ROOT_DIR/.integrationtests/checksums_need_updating.json
 Mismatch __examples__/checksums_need_updating/a.js:4
 Looks like you changed the target content for sync-tag 'update_me' in '__examples__/checksums_need_updating/b.py:3'
 Make sure you've made corresponding changes in the source file, if necessary (45678 != 249234014)
@@ -168,7 +168,7 @@ exports[`Integration Tests (see __examples__ folder) Example checksums_need_upda
     "**/checksums_need_updating/**"
   ],
   "json": true,
-  "cachePath": "checksums_need_updating.json",
+  "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -216,12 +216,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
-  "cachePath": "checksums_need_updating.json",
+  "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/checksums_need_updating.json
+Info     Loading cache from ROOT_DIR/.integrationtests/checksums_need_updating.json
 {
     "version": "0.0.0",
     "launchString": "checksync -u __examples__/checksums_need_updating/a.js __examples__/checksums_need_updating/b.py __examples__/checksums_need_updating/c.jsx",
@@ -297,7 +297,7 @@ exports[`Integration Tests (see __examples__ folder) Example checksums_need_upda
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
-  "cachePath": "checksums_need_updating.json",
+  "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -345,7 +345,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/checksums_need_updating/**"
   ],
-  "cachePath": "checksums_need_updating.json",
+  "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -365,7 +365,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/checksums_need_updating/b.py",
     "ROOT_DIR/__examples__/checksums_need_updating/c.jsx"
 ]
-Info     Cache written to ROOT_DIR/checksums_need_updating.json"
+Info     Cache written to ROOT_DIR/.integrationtests/checksums_need_updating.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example content_after_start should report example content_after_start to match snapshot for scenario autofix 1`] = `
@@ -375,7 +375,7 @@ exports[`Integration Tests (see __examples__ folder) Example content_after_start
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "content_after_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -423,13 +423,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
-  "cachePath": "content_after_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/content_after_start.json
+Info     Loading cache from ROOT_DIR/.integrationtests/content_after_start.json
 Verbose  __examples__/content_after_start/a.js
 File has errors; skipping auto-fix
 Fix      __examples__/content_after_start/a.js:3
@@ -460,7 +460,7 @@ exports[`Integration Tests (see __examples__ folder) Example content_after_start
   "includeGlobs": [
     "**/content_after_start/**"
   ],
-  "cachePath": "content_after_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -508,12 +508,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
-  "cachePath": "content_after_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/content_after_start.json
+Info     Loading cache from ROOT_DIR/.integrationtests/content_after_start.json
 Mismatch __examples__/content_after_start/a.js:3
 Looks like you changed the target content for sync-tag 'content_after_start' in '__examples__/content_after_start/b.py:3'
 Make sure you've made corresponding changes in the source file, if necessary (No checksum != 249234014)
@@ -547,7 +547,7 @@ exports[`Integration Tests (see __examples__ folder) Example content_after_start
     "**/content_after_start/**"
   ],
   "json": true,
-  "cachePath": "content_after_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -595,12 +595,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
-  "cachePath": "content_after_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/content_after_start.json
+Info     Loading cache from ROOT_DIR/.integrationtests/content_after_start.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -691,7 +691,7 @@ exports[`Integration Tests (see __examples__ folder) Example content_after_start
   "includeGlobs": [
     "**/content_after_start/**"
   ],
-  "cachePath": "content_after_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -739,7 +739,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/content_after_start/**"
   ],
-  "cachePath": "content_after_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -759,7 +759,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/content_after_start/b.py",
     "ROOT_DIR/__examples__/content_after_start/c.js"
 ]
-Info     Cache written to ROOT_DIR/content_after_start.json"
+Info     Cache written to ROOT_DIR/.integrationtests/content_after_start.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example correct_checksums should report example correct_checksums to match snapshot for scenario autofix 1`] = `
@@ -769,7 +769,7 @@ exports[`Integration Tests (see __examples__ folder) Example correct_checksums s
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "correct_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -817,13 +817,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
-  "cachePath": "correct_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/correct_checksums.json
+Info     Loading cache from ROOT_DIR/.integrationtests/correct_checksums.json
 🎉  Everything is in sync!"
 `;
 
@@ -832,7 +832,7 @@ exports[`Integration Tests (see __examples__ folder) Example correct_checksums s
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
-  "cachePath": "correct_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -880,12 +880,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
-  "cachePath": "correct_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/correct_checksums.json
+Info     Loading cache from ROOT_DIR/.integrationtests/correct_checksums.json
 🎉  Everything is in sync!"
 `;
 
@@ -895,7 +895,7 @@ exports[`Integration Tests (see __examples__ folder) Example correct_checksums s
     "**/correct_checksums/**"
   ],
   "json": true,
-  "cachePath": "correct_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -943,12 +943,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
-  "cachePath": "correct_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/correct_checksums.json
+Info     Loading cache from ROOT_DIR/.integrationtests/correct_checksums.json
 {
     "version": "0.0.0",
     "launchString": "checksync -u ",
@@ -961,7 +961,7 @@ exports[`Integration Tests (see __examples__ folder) Example correct_checksums s
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
-  "cachePath": "correct_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1009,7 +1009,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/correct_checksums/**"
   ],
-  "cachePath": "correct_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -1029,7 +1029,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/correct_checksums/b.py",
     "ROOT_DIR/__examples__/correct_checksums/c.jsx"
 ]
-Info     Cache written to ROOT_DIR/correct_checksums.json"
+Info     Cache written to ROOT_DIR/.integrationtests/correct_checksums.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example directory_target should report example directory_target to match snapshot for scenario autofix 1`] = `
@@ -1039,7 +1039,7 @@ exports[`Integration Tests (see __examples__ folder) Example directory_target sh
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "directory_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1087,13 +1087,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/directory_target/**"
   ],
-  "cachePath": "directory_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/directory_target.json
+Info     Loading cache from ROOT_DIR/.integrationtests/directory_target.json
 Error    __examples__/directory_target/example.js:3
 Sync-start for 'directory_target' points to '__examples__/directory_target/a_directory', which does not exist or is a directory
 Error    __examples__/directory_target/example.js:3
@@ -1109,7 +1109,7 @@ exports[`Integration Tests (see __examples__ folder) Example directory_target sh
   "includeGlobs": [
     "**/directory_target/**"
   ],
-  "cachePath": "directory_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1157,12 +1157,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/directory_target/**"
   ],
-  "cachePath": "directory_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/directory_target.json
+Info     Loading cache from ROOT_DIR/.integrationtests/directory_target.json
 Error    __examples__/directory_target/example.js:3
 Sync-start for 'directory_target' points to '__examples__/directory_target/a_directory', which does not exist or is a directory
 Error    __examples__/directory_target/example.js:3
@@ -1179,7 +1179,7 @@ exports[`Integration Tests (see __examples__ folder) Example directory_target sh
     "**/directory_target/**"
   ],
   "json": true,
-  "cachePath": "directory_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1227,12 +1227,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/directory_target/**"
   ],
-  "cachePath": "directory_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/directory_target.json
+Info     Loading cache from ROOT_DIR/.integrationtests/directory_target.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -1263,7 +1263,7 @@ exports[`Integration Tests (see __examples__ folder) Example directory_target sh
   "includeGlobs": [
     "**/directory_target/**"
   ],
-  "cachePath": "directory_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1311,7 +1311,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/directory_target/**"
   ],
-  "cachePath": "directory_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -1330,7 +1330,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/directory_target/a_directory/somefile.js",
     "ROOT_DIR/__examples__/directory_target/example.js"
 ]
-Info     Cache written to ROOT_DIR/directory_target.json"
+Info     Cache written to ROOT_DIR/.integrationtests/directory_target.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example duplicate-target should report example duplicate-target to match snapshot for scenario autofix 1`] = `
@@ -1340,7 +1340,7 @@ exports[`Integration Tests (see __examples__ folder) Example duplicate-target sh
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "duplicate_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1388,13 +1388,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
-  "cachePath": "duplicate_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/duplicate_target.json
+Info     Loading cache from ROOT_DIR/.integrationtests/duplicate_target.json
 Verbose  __examples__/duplicate-target/a.js
 File has errors; skipping auto-fix
 Fix      __examples__/duplicate-target/a.js:4
@@ -1418,7 +1418,7 @@ exports[`Integration Tests (see __examples__ folder) Example duplicate-target sh
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
-  "cachePath": "duplicate_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1466,12 +1466,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
-  "cachePath": "duplicate_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/duplicate_target.json
+Info     Loading cache from ROOT_DIR/.integrationtests/duplicate_target.json
 Warning  __examples__/duplicate-target/a.js:5
 Duplicate target for sync-tag 'update_me'
 Mismatch __examples__/duplicate-target/a.js:4
@@ -1496,7 +1496,7 @@ exports[`Integration Tests (see __examples__ folder) Example duplicate-target sh
     "**/duplicate-target/**"
   ],
   "json": true,
-  "cachePath": "duplicate_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1544,12 +1544,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
-  "cachePath": "duplicate_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/duplicate_target.json
+Info     Loading cache from ROOT_DIR/.integrationtests/duplicate_target.json
 {
     "version": "0.0.0",
     "launchString": "checksync -u __examples__/duplicate-target/a.js __examples__/duplicate-target/b.py",
@@ -1622,7 +1622,7 @@ exports[`Integration Tests (see __examples__ folder) Example duplicate-target sh
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
-  "cachePath": "duplicate_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1670,7 +1670,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/duplicate-target/**"
   ],
-  "cachePath": "duplicate_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -1689,7 +1689,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/duplicate-target/a.js",
     "ROOT_DIR/__examples__/duplicate-target/b.py"
 ]
-Info     Cache written to ROOT_DIR/duplicate_target.json"
+Info     Cache written to ROOT_DIR/.integrationtests/duplicate_target.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example empty_tag should report example empty_tag to match snapshot for scenario autofix 1`] = `
@@ -1699,7 +1699,7 @@ exports[`Integration Tests (see __examples__ folder) Example empty_tag should re
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "empty_tag.json",
+  "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1747,13 +1747,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
-  "cachePath": "empty_tag.json",
+  "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/empty_tag.json
+Info     Loading cache from ROOT_DIR/.integrationtests/empty_tag.json
 Error    __examples__/empty_tag/a.js:2
 Sync-tag 'no_content' has no content
 
@@ -1767,7 +1767,7 @@ exports[`Integration Tests (see __examples__ folder) Example empty_tag should re
   "includeGlobs": [
     "**/empty_tag/**"
   ],
-  "cachePath": "empty_tag.json",
+  "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1815,12 +1815,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
-  "cachePath": "empty_tag.json",
+  "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/empty_tag.json
+Info     Loading cache from ROOT_DIR/.integrationtests/empty_tag.json
 Error    __examples__/empty_tag/a.js:2
 Sync-tag 'no_content' has no content
 
@@ -1835,7 +1835,7 @@ exports[`Integration Tests (see __examples__ folder) Example empty_tag should re
     "**/empty_tag/**"
   ],
   "json": true,
-  "cachePath": "empty_tag.json",
+  "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1883,12 +1883,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
-  "cachePath": "empty_tag.json",
+  "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/empty_tag.json
+Info     Loading cache from ROOT_DIR/.integrationtests/empty_tag.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -1912,7 +1912,7 @@ exports[`Integration Tests (see __examples__ folder) Example empty_tag should re
   "includeGlobs": [
     "**/empty_tag/**"
   ],
-  "cachePath": "empty_tag.json",
+  "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -1960,7 +1960,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/empty_tag/**"
   ],
-  "cachePath": "empty_tag.json",
+  "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -1979,7 +1979,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/empty_tag/a.js",
     "ROOT_DIR/__examples__/empty_tag/b.js"
 ]
-Info     Cache written to ROOT_DIR/empty_tag.json"
+Info     Cache written to ROOT_DIR/.integrationtests/empty_tag.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example end_with_no_start should report example end_with_no_start to match snapshot for scenario autofix 1`] = `
@@ -1989,7 +1989,7 @@ exports[`Integration Tests (see __examples__ folder) Example end_with_no_start s
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "end_with_no_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2037,13 +2037,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
-  "cachePath": "end_with_no_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/end_with_no_start.json
+Info     Loading cache from ROOT_DIR/.integrationtests/end_with_no_start.json
 Error    __examples__/end_with_no_start/example.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
@@ -2057,7 +2057,7 @@ exports[`Integration Tests (see __examples__ folder) Example end_with_no_start s
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
-  "cachePath": "end_with_no_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2105,12 +2105,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
-  "cachePath": "end_with_no_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/end_with_no_start.json
+Info     Loading cache from ROOT_DIR/.integrationtests/end_with_no_start.json
 Error    __examples__/end_with_no_start/example.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
@@ -2125,7 +2125,7 @@ exports[`Integration Tests (see __examples__ folder) Example end_with_no_start s
     "**/end_with_no_start/**"
   ],
   "json": true,
-  "cachePath": "end_with_no_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2173,12 +2173,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
-  "cachePath": "end_with_no_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/end_with_no_start.json
+Info     Loading cache from ROOT_DIR/.integrationtests/end_with_no_start.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -2202,7 +2202,7 @@ exports[`Integration Tests (see __examples__ folder) Example end_with_no_start s
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
-  "cachePath": "end_with_no_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2250,7 +2250,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/end_with_no_start/**"
   ],
-  "cachePath": "end_with_no_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -2268,7 +2268,7 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/end_with_no_start/example.js"
 ]
-Info     Cache written to ROOT_DIR/end_with_no_start.json"
+Info     Cache written to ROOT_DIR/.integrationtests/end_with_no_start.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example excluded should report example excluded to match snapshot for scenario autofix 1`] = `
@@ -2278,7 +2278,7 @@ exports[`Integration Tests (see __examples__ folder) Example excluded should rep
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "excluded.json",
+  "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2326,13 +2326,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/excluded/**"
   ],
-  "cachePath": "excluded.json",
+  "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/excluded.json
+Info     Loading cache from ROOT_DIR/.integrationtests/excluded.json
 Error    Unable to load cache"
 `;
 
@@ -2341,7 +2341,7 @@ exports[`Integration Tests (see __examples__ folder) Example excluded should rep
   "includeGlobs": [
     "**/excluded/**"
   ],
-  "cachePath": "excluded.json",
+  "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2389,12 +2389,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/excluded/**"
   ],
-  "cachePath": "excluded.json",
+  "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/excluded.json
+Info     Loading cache from ROOT_DIR/.integrationtests/excluded.json
 Error    Unable to load cache"
 `;
 
@@ -2404,7 +2404,7 @@ exports[`Integration Tests (see __examples__ folder) Example excluded should rep
     "**/excluded/**"
   ],
   "json": true,
-  "cachePath": "excluded.json",
+  "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2452,12 +2452,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/excluded/**"
   ],
-  "cachePath": "excluded.json",
+  "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/excluded.json
+Info     Loading cache from ROOT_DIR/.integrationtests/excluded.json
 Error    Unable to load cache"
 `;
 
@@ -2466,7 +2466,7 @@ exports[`Integration Tests (see __examples__ folder) Example excluded should rep
   "includeGlobs": [
     "**/excluded/**"
   ],
-  "cachePath": "excluded.json",
+  "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2514,7 +2514,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/excluded/**"
   ],
-  "cachePath": "excluded.json",
+  "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -2540,7 +2540,7 @@ exports[`Integration Tests (see __examples__ folder) Example ignore_files_at_dif
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "ignore_files_at_different_depths.json",
+  "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2588,13 +2588,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
-  "cachePath": "ignore_files_at_different_depths.json",
+  "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/ignore_files_at_different_depths.json
+Info     Loading cache from ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json
 Error    __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
@@ -2608,7 +2608,7 @@ exports[`Integration Tests (see __examples__ folder) Example ignore_files_at_dif
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
-  "cachePath": "ignore_files_at_different_depths.json",
+  "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2656,12 +2656,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
-  "cachePath": "ignore_files_at_different_depths.json",
+  "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/ignore_files_at_different_depths.json
+Info     Loading cache from ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json
 Error    __examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js:5
 Sync-end for 'end_with_no_start' found, but there was no corresponding sync-start
 
@@ -2676,7 +2676,7 @@ exports[`Integration Tests (see __examples__ folder) Example ignore_files_at_dif
     "**/ignore_files_at_different_depths/**"
   ],
   "json": true,
-  "cachePath": "ignore_files_at_different_depths.json",
+  "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2724,12 +2724,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
-  "cachePath": "ignore_files_at_different_depths.json",
+  "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/ignore_files_at_different_depths.json
+Info     Loading cache from ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -2753,7 +2753,7 @@ exports[`Integration Tests (see __examples__ folder) Example ignore_files_at_dif
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
-  "cachePath": "ignore_files_at_different_depths.json",
+  "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2801,7 +2801,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/ignore_files_at_different_depths/**"
   ],
-  "cachePath": "ignore_files_at_different_depths.json",
+  "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -2826,7 +2826,7 @@ Verbose  UNIGNORED: __examples__/ignore_files_at_different_depths/some/ignorethe
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignorethesewhennotinsome/bad-sync-tags-that-get-parsed.js"
 ]
-Info     Cache written to ROOT_DIR/ignore_files_at_different_depths.json"
+Info     Cache written to ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example malformed_end should report example malformed_end to match snapshot for scenario autofix 1`] = `
@@ -2836,7 +2836,7 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_end shoul
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "malformed_end.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2884,13 +2884,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_end/**"
   ],
-  "cachePath": "malformed_end.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/malformed_end.json
+Info     Loading cache from ROOT_DIR/.integrationtests/malformed_end.json
 Error    __examples__/malformed_end/malformed_badid.js:7
 Malformed sync-end: format should be 'sync-end:<label>'
 Error    __examples__/malformed_end/malformed_badid.js:4
@@ -2911,7 +2911,7 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_end shoul
   "includeGlobs": [
     "**/malformed_end/**"
   ],
-  "cachePath": "malformed_end.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -2959,12 +2959,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_end/**"
   ],
-  "cachePath": "malformed_end.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/malformed_end.json
+Info     Loading cache from ROOT_DIR/.integrationtests/malformed_end.json
 Error    __examples__/malformed_end/malformed_badid.js:7
 Malformed sync-end: format should be 'sync-end:<label>'
 Error    __examples__/malformed_end/malformed_badid.js:4
@@ -2986,7 +2986,7 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_end shoul
     "**/malformed_end/**"
   ],
   "json": true,
-  "cachePath": "malformed_end.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3034,12 +3034,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_end/**"
   ],
-  "cachePath": "malformed_end.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/malformed_end.json
+Info     Loading cache from ROOT_DIR/.integrationtests/malformed_end.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -3086,7 +3086,7 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_end shoul
   "includeGlobs": [
     "**/malformed_end/**"
   ],
-  "cachePath": "malformed_end.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3134,7 +3134,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_end/**"
   ],
-  "cachePath": "malformed_end.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -3153,7 +3153,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/malformed_end/malformed_badid.js",
     "ROOT_DIR/__examples__/malformed_end/malformed_noid.js"
 ]
-Info     Cache written to ROOT_DIR/malformed_end.json"
+Info     Cache written to ROOT_DIR/.integrationtests/malformed_end.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example malformed_start should report example malformed_start to match snapshot for scenario autofix 1`] = `
@@ -3163,7 +3163,7 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_start sho
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "malformed_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3211,13 +3211,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
-  "cachePath": "malformed_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/malformed_start.json
+Info     Loading cache from ROOT_DIR/.integrationtests/malformed_start.json
 Error    __examples__/malformed_start/malformed_badchecksum.js:4
 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
 Error    __examples__/malformed_start/malformed_badchecksum.js:7
@@ -3243,7 +3243,7 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_start sho
   "includeGlobs": [
     "**/malformed_start/**"
   ],
-  "cachePath": "malformed_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3291,12 +3291,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
-  "cachePath": "malformed_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/malformed_start.json
+Info     Loading cache from ROOT_DIR/.integrationtests/malformed_start.json
 Error    __examples__/malformed_start/malformed_badchecksum.js:4
 Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'
 Error    __examples__/malformed_start/malformed_badchecksum.js:7
@@ -3323,7 +3323,7 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_start sho
     "**/malformed_start/**"
   ],
   "json": true,
-  "cachePath": "malformed_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3371,12 +3371,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
-  "cachePath": "malformed_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/malformed_start.json
+Info     Loading cache from ROOT_DIR/.integrationtests/malformed_start.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -3439,7 +3439,7 @@ exports[`Integration Tests (see __examples__ folder) Example malformed_start sho
   "includeGlobs": [
     "**/malformed_start/**"
   ],
-  "cachePath": "malformed_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3487,7 +3487,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/malformed_start/**"
   ],
-  "cachePath": "malformed_start.json",
+  "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -3507,7 +3507,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/malformed_start/malformed_badid.js",
     "ROOT_DIR/__examples__/malformed_start/malformed_onlytagid.js"
 ]
-Info     Cache written to ROOT_DIR/malformed_start.json"
+Info     Cache written to ROOT_DIR/.integrationtests/malformed_start.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example missing_target should report example missing_target to match snapshot for scenario autofix 1`] = `
@@ -3517,7 +3517,7 @@ exports[`Integration Tests (see __examples__ folder) Example missing_target shou
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "missing_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3565,13 +3565,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
-  "cachePath": "missing_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/missing_target.json
+Info     Loading cache from ROOT_DIR/.integrationtests/missing_target.json
 Error    __examples__/missing_target/example.js:3
 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
 Error    __examples__/missing_target/example.js:3
@@ -3587,7 +3587,7 @@ exports[`Integration Tests (see __examples__ folder) Example missing_target shou
   "includeGlobs": [
     "**/missing_target/**"
   ],
-  "cachePath": "missing_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3635,12 +3635,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
-  "cachePath": "missing_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/missing_target.json
+Info     Loading cache from ROOT_DIR/.integrationtests/missing_target.json
 Error    __examples__/missing_target/example.js:3
 Sync-start for 'missing_target' points to '__examples__/missing_target/missing_target.py', which does not exist or is a directory
 Error    __examples__/missing_target/example.js:3
@@ -3657,7 +3657,7 @@ exports[`Integration Tests (see __examples__ folder) Example missing_target shou
     "**/missing_target/**"
   ],
   "json": true,
-  "cachePath": "missing_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3705,12 +3705,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
-  "cachePath": "missing_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/missing_target.json
+Info     Loading cache from ROOT_DIR/.integrationtests/missing_target.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -3741,7 +3741,7 @@ exports[`Integration Tests (see __examples__ folder) Example missing_target shou
   "includeGlobs": [
     "**/missing_target/**"
   ],
-  "cachePath": "missing_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3789,7 +3789,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/missing_target/**"
   ],
-  "cachePath": "missing_target.json",
+  "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -3807,7 +3807,7 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/missing_target/example.js"
 ]
-Info     Cache written to ROOT_DIR/missing_target.json"
+Info     Cache written to ROOT_DIR/.integrationtests/missing_target.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example no_back_reference should report example no_back_reference to match snapshot for scenario autofix 1`] = `
@@ -3817,7 +3817,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_back_reference s
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "no_back_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3865,13 +3865,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
-  "cachePath": "no_back_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/no_back_reference.json
+Info     Loading cache from ROOT_DIR/.integrationtests/no_back_reference.json
 Error    __examples__/no_back_reference/file1.js:1
 No return tag named 'markerID' in '__examples__/no_back_reference/file2.js'
 
@@ -3885,7 +3885,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_back_reference s
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
-  "cachePath": "no_back_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -3933,12 +3933,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
-  "cachePath": "no_back_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/no_back_reference.json
+Info     Loading cache from ROOT_DIR/.integrationtests/no_back_reference.json
 Error    __examples__/no_back_reference/file1.js:1
 No return tag named 'markerID' in '__examples__/no_back_reference/file2.js'
 
@@ -3953,7 +3953,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_back_reference s
     "**/no_back_reference/**"
   ],
   "json": true,
-  "cachePath": "no_back_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4001,12 +4001,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
-  "cachePath": "no_back_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/no_back_reference.json
+Info     Loading cache from ROOT_DIR/.integrationtests/no_back_reference.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -4030,7 +4030,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_back_reference s
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
-  "cachePath": "no_back_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4078,7 +4078,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_back_reference/**"
   ],
-  "cachePath": "no_back_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -4097,7 +4097,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/no_back_reference/file1.js",
     "ROOT_DIR/__examples__/no_back_reference/file2.js"
 ]
-Info     Cache written to ROOT_DIR/no_back_reference.json"
+Info     Cache written to ROOT_DIR/.integrationtests/no_back_reference.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example no_checksums should report example no_checksums to match snapshot for scenario autofix 1`] = `
@@ -4107,7 +4107,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_checksums should
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "no_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4155,13 +4155,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
-  "cachePath": "no_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/no_checksums.json
+Info     Loading cache from ROOT_DIR/.integrationtests/no_checksums.json
 Verbose  __examples__/no_checksums/example_one-a.js
 File has errors; skipping auto-fix
 Fix      __examples__/no_checksums/example_one-a.js:3
@@ -4183,7 +4183,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_checksums should
   "includeGlobs": [
     "**/no_checksums/**"
   ],
-  "cachePath": "no_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4231,12 +4231,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
-  "cachePath": "no_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/no_checksums.json
+Info     Loading cache from ROOT_DIR/.integrationtests/no_checksums.json
 Mismatch __examples__/no_checksums/example_one-a.js:3
 Looks like you changed the target content for sync-tag 'example_one' in '__examples__/no_checksums/example_one-b.py:3'
 Make sure you've made corresponding changes in the source file, if necessary (No checksum != 249234014)
@@ -4256,7 +4256,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_checksums should
     "**/no_checksums/**"
   ],
   "json": true,
-  "cachePath": "no_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4304,12 +4304,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
-  "cachePath": "no_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/no_checksums.json
+Info     Loading cache from ROOT_DIR/.integrationtests/no_checksums.json
 {
     "version": "0.0.0",
     "launchString": "checksync -u __examples__/no_checksums/example_one-a.js __examples__/no_checksums/example_one-b.py",
@@ -4355,7 +4355,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_checksums should
   "includeGlobs": [
     "**/no_checksums/**"
   ],
-  "cachePath": "no_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4403,7 +4403,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_checksums/**"
   ],
-  "cachePath": "no_checksums.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -4422,7 +4422,7 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/no_checksums/example_one-a.js",
     "ROOT_DIR/__examples__/no_checksums/example_one-b.py"
 ]
-Info     Cache written to ROOT_DIR/no_checksums.json"
+Info     Cache written to ROOT_DIR/.integrationtests/no_checksums.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example no_self_reference should report example no_self_reference to match snapshot for scenario autofix 1`] = `
@@ -4432,7 +4432,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_self_reference s
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "no_self_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4480,13 +4480,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
-  "cachePath": "no_self_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/no_self_reference.json
+Info     Loading cache from ROOT_DIR/.integrationtests/no_self_reference.json
 Error    __examples__/no_self_reference/example.js:3
 Sync-tag 'example_three' cannot target itself
 
@@ -4505,7 +4505,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_self_reference s
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
-  "cachePath": "no_self_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4553,12 +4553,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
-  "cachePath": "no_self_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/no_self_reference.json
+Info     Loading cache from ROOT_DIR/.integrationtests/no_self_reference.json
 Error    __examples__/no_self_reference/example.js:3
 Sync-tag 'example_three' cannot target itself
 Mismatch __examples__/no_self_reference/example.js:3
@@ -4581,7 +4581,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_self_reference s
     "**/no_self_reference/**"
   ],
   "json": true,
-  "cachePath": "no_self_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4629,12 +4629,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
-  "cachePath": "no_self_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/no_self_reference.json
+Info     Loading cache from ROOT_DIR/.integrationtests/no_self_reference.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -4672,7 +4672,7 @@ exports[`Integration Tests (see __examples__ folder) Example no_self_reference s
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
-  "cachePath": "no_self_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4720,7 +4720,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/no_self_reference/**"
   ],
-  "cachePath": "no_self_reference.json",
+  "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -4738,7 +4738,7 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/no_self_reference/example.js"
 ]
-Info     Cache written to ROOT_DIR/no_self_reference.json"
+Info     Cache written to ROOT_DIR/.integrationtests/no_self_reference.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example remote_tags_broken should report example remote_tags_broken to match snapshot for scenario autofix 1`] = `
@@ -4748,7 +4748,7 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_broken 
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "remote_tags_broken.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4796,13 +4796,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
-  "cachePath": "remote_tags_broken.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/remote_tags_broken.json
+Info     Loading cache from ROOT_DIR/.integrationtests/remote_tags_broken.json
 Verbose  __examples__/remote_tags_broken/example.jsx
 File has errors; skipping auto-fix
 Fix      __examples__/remote_tags_broken/example.jsx:3
@@ -4820,7 +4820,7 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_broken 
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
-  "cachePath": "remote_tags_broken.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4868,12 +4868,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
-  "cachePath": "remote_tags_broken.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/remote_tags_broken.json
+Info     Loading cache from ROOT_DIR/.integrationtests/remote_tags_broken.json
 Mismatch __examples__/remote_tags_broken/example.jsx:3
 Looks like you changed the content of sync-tag 'remote_target_self_hash' or the path of the file that contains the tag
 Make sure you've made corresponding changes at https://github.com/somewhatabstract/checksync/blob/b9433f22ed9cfdf6c79edfd7254670ff53f82f7c/__examples__/remote_tags_match/example.jsx#L3, if necessary (840225308 != 1603869099)
@@ -4890,7 +4890,7 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_broken 
     "**/remote_tags_broken/**"
   ],
   "json": true,
-  "cachePath": "remote_tags_broken.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -4938,12 +4938,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
-  "cachePath": "remote_tags_broken.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/remote_tags_broken.json
+Info     Loading cache from ROOT_DIR/.integrationtests/remote_tags_broken.json
 {
     "version": "0.0.0",
     "launchString": "checksync -u __examples__/remote_tags_broken/example.jsx",
@@ -4973,7 +4973,7 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_broken 
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
-  "cachePath": "remote_tags_broken.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -5021,7 +5021,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_broken/**"
   ],
-  "cachePath": "remote_tags_broken.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -5039,7 +5039,7 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/remote_tags_broken/example.jsx"
 ]
-Info     Cache written to ROOT_DIR/remote_tags_broken.json"
+Info     Cache written to ROOT_DIR/.integrationtests/remote_tags_broken.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example remote_tags_match should report example remote_tags_match to match snapshot for scenario autofix 1`] = `
@@ -5049,7 +5049,7 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_match s
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "remote_tags_match.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -5097,13 +5097,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
-  "cachePath": "remote_tags_match.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/remote_tags_match.json
+Info     Loading cache from ROOT_DIR/.integrationtests/remote_tags_match.json
 🎉  Everything is in sync!"
 `;
 
@@ -5112,7 +5112,7 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_match s
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
-  "cachePath": "remote_tags_match.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -5160,12 +5160,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
-  "cachePath": "remote_tags_match.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/remote_tags_match.json
+Info     Loading cache from ROOT_DIR/.integrationtests/remote_tags_match.json
 🎉  Everything is in sync!"
 `;
 
@@ -5175,7 +5175,7 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_match s
     "**/remote_tags_match/**"
   ],
   "json": true,
-  "cachePath": "remote_tags_match.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -5223,12 +5223,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
-  "cachePath": "remote_tags_match.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/remote_tags_match.json
+Info     Loading cache from ROOT_DIR/.integrationtests/remote_tags_match.json
 {
     "version": "0.0.0",
     "launchString": "checksync -u ",
@@ -5241,7 +5241,7 @@ exports[`Integration Tests (see __examples__ folder) Example remote_tags_match s
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
-  "cachePath": "remote_tags_match.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -5289,7 +5289,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/remote_tags_match/**"
   ],
-  "cachePath": "remote_tags_match.json",
+  "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -5307,7 +5307,7 @@ Verbose  Exclude globs: [
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/remote_tags_match/example.jsx"
 ]
-Info     Cache written to ROOT_DIR/remote_tags_match.json"
+Info     Cache written to ROOT_DIR/.integrationtests/remote_tags_match.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example unterminated_marker should report example unterminated_marker to match snapshot for scenario autofix 1`] = `
@@ -5317,7 +5317,7 @@ exports[`Integration Tests (see __examples__ folder) Example unterminated_marker
   ],
   "autoFix": true,
   "dryRun": true,
-  "cachePath": "unterminated_marker.json",
+  "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -5365,13 +5365,13 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
-  "cachePath": "unterminated_marker.json",
+  "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
 Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/unterminated_marker.json
+Info     Loading cache from ROOT_DIR/.integrationtests/unterminated_marker.json
 Error    __examples__/unterminated_marker/example_two-a.js:3
 No return tag named 'example_two' in '__examples__/unterminated_marker/example_two-b.py'
 Error    __examples__/unterminated_marker/example_two-b.py:3
@@ -5388,7 +5388,7 @@ exports[`Integration Tests (see __examples__ folder) Example unterminated_marker
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
-  "cachePath": "unterminated_marker.json",
+  "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -5436,12 +5436,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
-  "cachePath": "unterminated_marker.json",
+  "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/unterminated_marker.json
+Info     Loading cache from ROOT_DIR/.integrationtests/unterminated_marker.json
 Error    __examples__/unterminated_marker/example_two-a.js:3
 No return tag named 'example_two' in '__examples__/unterminated_marker/example_two-b.py'
 Error    __examples__/unterminated_marker/example_two-b.py:3
@@ -5459,7 +5459,7 @@ exports[`Integration Tests (see __examples__ folder) Example unterminated_marker
     "**/unterminated_marker/**"
   ],
   "json": true,
-  "cachePath": "unterminated_marker.json",
+  "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -5507,12 +5507,12 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
-  "cachePath": "unterminated_marker.json",
+  "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
 }
-Info     Loading cache from ROOT_DIR/unterminated_marker.json
+Info     Loading cache from ROOT_DIR/.integrationtests/unterminated_marker.json
 Error    🛑  Unfixable errors found. Fix the errors and try again.
 {
     "version": "0.0.0",
@@ -5545,7 +5545,7 @@ exports[`Integration Tests (see __examples__ folder) Example unterminated_marker
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
-  "cachePath": "unterminated_marker.json",
+  "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "write"
 }
 Verbose  Looking for configuration file based on root marker...
@@ -5593,7 +5593,7 @@ Verbose  Combined options with defaults: {
   "includeGlobs": [
     "**/unterminated_marker/**"
   ],
-  "cachePath": "unterminated_marker.json",
+  "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "write",
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery."
@@ -5612,5 +5612,5 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/unterminated_marker/example_two-a.js",
     "ROOT_DIR/__examples__/unterminated_marker/example_two-b.py"
 ]
-Info     Cache written to ROOT_DIR/unterminated_marker.json"
+Info     Cache written to ROOT_DIR/.integrationtests/unterminated_marker.json"
 `;

--- a/src/__tests__/check-sync.test.ts
+++ b/src/__tests__/check-sync.test.ts
@@ -1,221 +1,821 @@
 import * as GetFiles from "../get-files";
 import * as GetMarkersFromFiles from "../get-markers-from-files";
 import * as ProcessCache from "../process-cache";
+import * as LoadCache from "../load-cache";
+import * as OutputCache from "../output-cache";
 import Logger from "../logger";
 
 import checkSync from "../check-sync";
 import {ExitCode} from "../exit-codes";
 
 import {Options} from "../types";
+import {ExitError} from "../exit-error";
 
 jest.mock("../get-files");
 jest.mock("../get-markers-from-files");
 jest.mock("../process-cache");
+jest.mock("../load-cache");
+jest.mock("../output-cache");
 jest.mock("../cwd-relative-path");
 
 describe("#checkSync", () => {
-    it("should log message if dry run autofix", async () => {
-        // Arrange
-        const NullLogger = new Logger();
-        const logSpy = jest.spyOn(NullLogger, "info");
-        jest.spyOn(GetFiles, "default").mockResolvedValue([]);
+    describe("when cacheMode is ignore", () => {
+        it("should log message if dry run autofix", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            const logSpy = jest.spyOn(NullLogger, "info");
+            jest.spyOn(GetFiles, "default").mockResolvedValue([]);
 
-        // Act
-        await checkSync(
-            {
-                includeGlobs: ["glob1", "glob2"],
-                excludeGlobs: [],
-                ignoreFiles: [],
-                dryRun: true,
-                autoFix: true,
-                comments: ["//"],
-                json: false,
-                allowEmptyTags: false,
-                cachePath: "",
-                cacheMode: "ignore",
-            },
-            NullLogger,
-        );
+            // Act
+            await checkSync(
+                {
+                    includeGlobs: ["glob1", "glob2"],
+                    excludeGlobs: [],
+                    ignoreFiles: [],
+                    dryRun: true,
+                    autoFix: true,
+                    comments: ["//"],
+                    json: false,
+                    allowEmptyTags: false,
+                    cachePath: "",
+                    cacheMode: "ignore",
+                },
+                NullLogger,
+            );
 
-        // Assert
-        expect(logSpy).toHaveBeenCalledWith(
-            "DRY-RUN: Files will not be modified",
-        );
-    });
+            // Assert
+            expect(logSpy).toHaveBeenCalledWith(
+                "DRY-RUN: Files will not be modified",
+            );
+        });
 
-    it("should expand the globs to files", async () => {
-        // Arrange
-        const NullLogger = new Logger();
-        const getFilesSpy = jest
-            .spyOn(GetFiles, "default")
-            .mockResolvedValue([]);
+        it("should expand the globs to files", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            const getFilesSpy = jest
+                .spyOn(GetFiles, "default")
+                .mockResolvedValue([]);
 
-        // Act
-        await checkSync(
-            {
+            // Act
+            await checkSync(
+                {
+                    includeGlobs: ["glob1", "glob2"],
+                    excludeGlobs: [],
+                    ignoreFiles: [],
+                    dryRun: false,
+                    autoFix: true,
+                    comments: ["//"],
+                    json: false,
+                    allowEmptyTags: false,
+                    cachePath: "",
+                    cacheMode: "ignore",
+                },
+                NullLogger,
+            );
+
+            // Assert
+            expect(getFilesSpy).toHaveBeenCalledWith(
+                ["glob1", "glob2"],
+                [],
+                [],
+                NullLogger,
+            );
+        });
+
+        it("should log error when there are no matching files", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockResolvedValue([]);
+            const errorSpy = jest.spyOn(NullLogger, "error");
+            const options: Options = {
                 includeGlobs: ["glob1", "glob2"],
                 excludeGlobs: [],
                 ignoreFiles: [],
                 dryRun: false,
-                autoFix: true,
-                comments: ["//"],
-                json: false,
-                allowEmptyTags: false,
-                cachePath: "",
-                cacheMode: "ignore",
-            },
-            NullLogger,
-        );
-
-        // Assert
-        expect(getFilesSpy).toHaveBeenCalledWith(
-            ["glob1", "glob2"],
-            [],
-            [],
-            NullLogger,
-        );
-    });
-
-    it("should log error when there are no matching files", async () => {
-        // Arrange
-        const NullLogger = new Logger();
-        jest.spyOn(GetFiles, "default").mockResolvedValue([]);
-        const errorSpy = jest.spyOn(NullLogger, "error");
-        const options: Options = {
-            includeGlobs: ["glob1", "glob2"],
-            excludeGlobs: [],
-            ignoreFiles: [],
-            dryRun: false,
-            autoFix: false,
-            comments: ["//"],
-            json: false,
-            allowEmptyTags: false,
-            cachePath: "",
-            cacheMode: "ignore",
-        };
-
-        // Act
-        await checkSync(options, NullLogger);
-
-        // Assert
-        expect(errorSpy).toHaveBeenCalledWith("No matching files");
-    });
-
-    it("should return NO_FILES when there are no matching files", async () => {
-        // Arrange
-        const NullLogger = new Logger();
-        jest.spyOn(GetFiles, "default").mockResolvedValue([]);
-        const options: Options = {
-            includeGlobs: ["glob1", "glob2"],
-            excludeGlobs: [],
-            ignoreFiles: [],
-            dryRun: false,
-            autoFix: false,
-            comments: ["//"],
-            json: false,
-            allowEmptyTags: false,
-            cachePath: "",
-            cacheMode: "ignore",
-        };
-
-        // Act
-        const result = await checkSync(options, NullLogger);
-
-        // Assert
-        expect(result).toBe(ExitCode.NO_FILES);
-    });
-
-    it("should build a marker cache from the files", async () => {
-        // Arrange
-        const NullLogger = new Logger();
-        jest.spyOn(GetFiles, "default").mockResolvedValue(["filea", "fileb"]);
-        jest.spyOn(ProcessCache, "default").mockResolvedValue(ExitCode.SUCCESS);
-        const getMarkersFromFilesSpy = jest
-            .spyOn(GetMarkersFromFiles, "default")
-            .mockResolvedValue({});
-        const options: Options = {
-            includeGlobs: ["glob1", "glob2"],
-            excludeGlobs: [],
-            ignoreFiles: [],
-            dryRun: false,
-            autoFix: true,
-            comments: ["//"],
-            json: false,
-            allowEmptyTags: false,
-            cachePath: "",
-            cacheMode: "ignore",
-        };
-
-        // Act
-        await checkSync(options, NullLogger);
-
-        // Assert
-        expect(getMarkersFromFilesSpy).toHaveBeenCalledWith(options, [
-            "filea",
-            "fileb",
-        ]);
-    });
-
-    it("should invoke ProcessCache with options, cache, and log", async () => {
-        // Arrange
-        const NullLogger = new Logger();
-        const fakeCache: Record<string, any> = {};
-        jest.spyOn(GetFiles, "default").mockResolvedValue(["filea", "fileb"]);
-        jest.spyOn(GetMarkersFromFiles, "default").mockResolvedValue(fakeCache);
-        const ProcessCacheSpy = jest
-            .spyOn(ProcessCache, "default")
-            .mockResolvedValue(ExitCode.SUCCESS);
-        const options: Options = {
-            includeGlobs: ["glob1", "glob2"],
-            excludeGlobs: [],
-            ignoreFiles: [],
-            dryRun: false,
-            autoFix: false,
-            comments: ["//"],
-            rootMarker: "marker",
-            json: false,
-            allowEmptyTags: false,
-            cachePath: "",
-            cacheMode: "ignore",
-        };
-
-        // Act
-        await checkSync(options, NullLogger);
-
-        // Assert
-        expect(ProcessCacheSpy).toHaveBeenCalledWith(
-            options,
-            fakeCache,
-            NullLogger,
-        );
-    });
-
-    it("should return processCache result if no parsing errors", async () => {
-        // Arrange
-        const NullLogger = new Logger();
-        const fakeCache: Record<string, any> = {};
-        jest.spyOn(GetFiles, "default").mockResolvedValue(["filea", "fileb"]);
-        jest.spyOn(GetMarkersFromFiles, "default").mockResolvedValue(fakeCache);
-        jest.spyOn(ProcessCache, "default").mockResolvedValue(ExitCode.SUCCESS);
-
-        // Act
-        const result = await checkSync(
-            {
-                includeGlobs: [],
-                excludeGlobs: [],
-                ignoreFiles: [],
                 autoFix: false,
                 comments: ["//"],
-                dryRun: false,
                 json: false,
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
-            },
-            NullLogger,
-        );
+            };
 
-        // Assert
-        expect(result).toBe(ExitCode.SUCCESS);
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(errorSpy).toHaveBeenCalledWith("No matching files");
+        });
+
+        it("should return NO_FILES when there are no matching files", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockResolvedValue([]);
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
+            };
+
+            // Act
+            const result = await checkSync(options, NullLogger);
+
+            // Assert
+            expect(result).toBe(ExitCode.NO_FILES);
+        });
+
+        it("should log error when some unexpected error occurs", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockRejectedValue(
+                new Error("Unexpected error"),
+            );
+            const errorSpy = jest.spyOn(NullLogger, "error");
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(errorSpy).toHaveBeenCalledWith(
+                "Unexpected catastrophic error",
+            );
+        });
+
+        it("should return CATASTROPHIC when an unexpected error occurs", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockRejectedValue(
+                new Error("Unexpected error"),
+            );
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
+            };
+
+            // Act
+            const result = await checkSync(options, NullLogger);
+
+            // Assert
+            expect(result).toBe(ExitCode.CATASTROPHIC);
+        });
+
+        it("should build a marker cache from the files", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockResolvedValue([
+                "filea",
+                "fileb",
+            ]);
+            jest.spyOn(ProcessCache, "default").mockResolvedValue(
+                ExitCode.SUCCESS,
+            );
+            const getMarkersFromFilesSpy = jest
+                .spyOn(GetMarkersFromFiles, "default")
+                .mockResolvedValue({});
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: true,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(getMarkersFromFilesSpy).toHaveBeenCalledWith(options, [
+                "filea",
+                "fileb",
+            ]);
+        });
+
+        it("should invoke processCache with options, cache, and log", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            const fakeCache: Record<string, any> = {};
+            jest.spyOn(GetFiles, "default").mockResolvedValue([
+                "filea",
+                "fileb",
+            ]);
+            jest.spyOn(GetMarkersFromFiles, "default").mockResolvedValue(
+                fakeCache,
+            );
+            const processCacheSpy = jest
+                .spyOn(ProcessCache, "default")
+                .mockResolvedValue(ExitCode.SUCCESS);
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                rootMarker: "marker",
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(processCacheSpy).toHaveBeenCalledWith(
+                options,
+                fakeCache,
+                NullLogger,
+            );
+        });
+
+        it("should return processCache result if no parsing errors", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            const fakeCache: Record<string, any> = {};
+            jest.spyOn(GetFiles, "default").mockResolvedValue([
+                "filea",
+                "fileb",
+            ]);
+            jest.spyOn(GetMarkersFromFiles, "default").mockResolvedValue(
+                fakeCache,
+            );
+            jest.spyOn(ProcessCache, "default").mockResolvedValue(
+                ExitCode.SUCCESS,
+            );
+
+            // Act
+            const result = await checkSync(
+                {
+                    includeGlobs: [],
+                    excludeGlobs: [],
+                    ignoreFiles: [],
+                    autoFix: false,
+                    comments: ["//"],
+                    dryRun: false,
+                    json: false,
+                    allowEmptyTags: false,
+                    cachePath: "",
+                    cacheMode: "ignore",
+                },
+                NullLogger,
+            );
+
+            // Assert
+            expect(result).toBe(ExitCode.SUCCESS);
+        });
+    });
+
+    describe("when cache mode is read", () => {
+        it("should log message if dry run autofix", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            const logSpy = jest.spyOn(NullLogger, "info");
+            jest.spyOn(GetFiles, "default").mockResolvedValue([]);
+
+            // Act
+            await checkSync(
+                {
+                    includeGlobs: ["glob1", "glob2"],
+                    excludeGlobs: [],
+                    ignoreFiles: [],
+                    dryRun: true,
+                    autoFix: true,
+                    comments: ["//"],
+                    json: false,
+                    allowEmptyTags: false,
+                    cachePath: "",
+                    cacheMode: "read",
+                },
+                NullLogger,
+            );
+
+            // Assert
+            expect(logSpy).toHaveBeenCalledWith(
+                "DRY-RUN: Files will not be modified",
+            );
+        });
+
+        it("should log error when the cache can't be loaded", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockResolvedValue([]);
+            jest.spyOn(LoadCache, "loadCache").mockRejectedValue(
+                new ExitError("Can't load cache", ExitCode.BAD_CACHE),
+            );
+            const errorSpy = jest.spyOn(NullLogger, "error");
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "read",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(errorSpy).toHaveBeenCalledWith("Unable to load cache");
+        });
+
+        it("should return NO_FILES when there are no matching files", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(LoadCache, "loadCache").mockRejectedValue(
+                new ExitError("Can't load cache", ExitCode.BAD_CACHE),
+            );
+            jest.spyOn(GetFiles, "default").mockResolvedValue([]);
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "read",
+            };
+
+            // Act
+            const result = await checkSync(options, NullLogger);
+
+            // Assert
+            expect(result).toBe(ExitCode.BAD_CACHE);
+        });
+
+        it("should log error when some unexpected error occurs", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(LoadCache, "loadCache").mockRejectedValue(
+                new Error("UNEXPECTED ERROR"),
+            );
+            const errorSpy = jest.spyOn(NullLogger, "error");
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(errorSpy).toHaveBeenCalledWith(
+                "Unexpected catastrophic error",
+            );
+        });
+
+        it("should return CATASTROPHIC when an unexpected error occurs", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(LoadCache, "loadCache").mockRejectedValue(
+                new Error("UNEXPECTED ERROR"),
+            );
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
+            };
+
+            // Act
+            const result = await checkSync(options, NullLogger);
+
+            // Assert
+            expect(result).toBe(ExitCode.CATASTROPHIC);
+        });
+
+        it("should load the marker cache", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockResolvedValue([
+                "filea",
+                "fileb",
+            ]);
+            jest.spyOn(ProcessCache, "default").mockResolvedValue(
+                ExitCode.SUCCESS,
+            );
+            const loadCacheSpy = jest
+                .spyOn(LoadCache, "loadCache")
+                .mockResolvedValue({});
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: true,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "CACHE_FILE_PATH",
+                cacheMode: "read",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(loadCacheSpy).toHaveBeenCalledWith(
+                "CACHE_FILE_PATH",
+                NullLogger,
+            );
+        });
+
+        it("should invoke processCache with options, cache, and log", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            const fakeCache: Record<string, any> = {};
+            jest.spyOn(GetFiles, "default").mockResolvedValue([
+                "filea",
+                "fileb",
+            ]);
+            jest.spyOn(LoadCache, "loadCache").mockResolvedValue(fakeCache);
+            const processCacheSpy = jest
+                .spyOn(ProcessCache, "default")
+                .mockResolvedValue(ExitCode.SUCCESS);
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                rootMarker: "marker",
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "read",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(processCacheSpy).toHaveBeenCalledWith(
+                options,
+                fakeCache,
+                NullLogger,
+            );
+        });
+
+        it("should return processCache result if no parsing errors", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockResolvedValue([
+                "filea",
+                "fileb",
+            ]);
+            jest.spyOn(LoadCache, "loadCache").mockResolvedValue({});
+            jest.spyOn(ProcessCache, "default").mockResolvedValue(
+                ExitCode.SUCCESS,
+            );
+
+            // Act
+            const result = await checkSync(
+                {
+                    includeGlobs: [],
+                    excludeGlobs: [],
+                    ignoreFiles: [],
+                    autoFix: false,
+                    comments: ["//"],
+                    dryRun: false,
+                    json: false,
+                    allowEmptyTags: false,
+                    cachePath: "",
+                    cacheMode: "read",
+                },
+                NullLogger,
+            );
+
+            // Assert
+            expect(result).toBe(ExitCode.SUCCESS);
+        });
+    });
+
+    describe("when cache mode is write", () => {
+        it("should not log message if dry run autofix (these aren't meaningful in cache write mode)", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            const logSpy = jest.spyOn(NullLogger, "info");
+            jest.spyOn(GetFiles, "default").mockResolvedValue([]);
+
+            // Act
+            await checkSync(
+                {
+                    includeGlobs: ["glob1", "glob2"],
+                    excludeGlobs: [],
+                    ignoreFiles: [],
+                    dryRun: true,
+                    autoFix: true,
+                    comments: ["//"],
+                    json: false,
+                    allowEmptyTags: false,
+                    cachePath: "",
+                    cacheMode: "write",
+                },
+                NullLogger,
+            );
+
+            // Assert
+            expect(logSpy).not.toHaveBeenCalled();
+        });
+
+        it("should expand the globs to files", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            const getFilesSpy = jest
+                .spyOn(GetFiles, "default")
+                .mockResolvedValue([]);
+
+            // Act
+            await checkSync(
+                {
+                    includeGlobs: ["glob1", "glob2"],
+                    excludeGlobs: [],
+                    ignoreFiles: [],
+                    dryRun: false,
+                    autoFix: true,
+                    comments: ["//"],
+                    json: false,
+                    allowEmptyTags: false,
+                    cachePath: "",
+                    cacheMode: "write",
+                },
+                NullLogger,
+            );
+
+            // Assert
+            expect(getFilesSpy).toHaveBeenCalledWith(
+                ["glob1", "glob2"],
+                [],
+                [],
+                NullLogger,
+            );
+        });
+
+        it("should log error when there are no matching files", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockResolvedValue([]);
+            const errorSpy = jest.spyOn(NullLogger, "error");
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "write",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(errorSpy).toHaveBeenCalledWith("No matching files");
+        });
+
+        it("should return NO_FILES when there are no matching files", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockResolvedValue([]);
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "write",
+            };
+
+            // Act
+            const result = await checkSync(options, NullLogger);
+
+            // Assert
+            expect(result).toBe(ExitCode.NO_FILES);
+        });
+
+        it("should log error when some unexpected error occurs", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockRejectedValue(
+                new Error("Unexpected error"),
+            );
+            const errorSpy = jest.spyOn(NullLogger, "error");
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "write",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(errorSpy).toHaveBeenCalledWith(
+                "Unexpected catastrophic error",
+            );
+        });
+
+        it("should return CATASTROPHIC when an unexpected error occurs", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockRejectedValue(
+                new Error("Unexpected error"),
+            );
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "write",
+            };
+
+            // Act
+            const result = await checkSync(options, NullLogger);
+
+            // Assert
+            expect(result).toBe(ExitCode.CATASTROPHIC);
+        });
+
+        it("should build a marker cache from the files", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockResolvedValue([
+                "filea",
+                "fileb",
+            ]);
+            jest.spyOn(ProcessCache, "default").mockResolvedValue(
+                ExitCode.SUCCESS,
+            );
+            const getMarkersFromFilesSpy = jest
+                .spyOn(GetMarkersFromFiles, "default")
+                .mockResolvedValue({});
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: true,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "write",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(getMarkersFromFilesSpy).toHaveBeenCalledWith(options, [
+                "filea",
+                "fileb",
+            ]);
+        });
+
+        it("should invoke outputCache with options, cache, and log", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            const fakeCache: Record<string, any> = {};
+            jest.spyOn(GetFiles, "default").mockResolvedValue([
+                "filea",
+                "fileb",
+            ]);
+            jest.spyOn(GetMarkersFromFiles, "default").mockResolvedValue(
+                fakeCache,
+            );
+            const outputCacheSpy = jest
+                .spyOn(OutputCache, "outputCache")
+                .mockResolvedValue(ExitCode.SUCCESS);
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: false,
+                comments: ["//"],
+                rootMarker: "marker",
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "write",
+            };
+
+            // Act
+            await checkSync(options, NullLogger);
+
+            // Assert
+            expect(outputCacheSpy).toHaveBeenCalledWith(
+                options,
+                fakeCache,
+                NullLogger,
+            );
+        });
+
+        it("should return outputCache result if no parsing errors", async () => {
+            // Arrange
+            const NullLogger = new Logger();
+            jest.spyOn(GetFiles, "default").mockResolvedValue([
+                "filea",
+                "fileb",
+            ]);
+            jest.spyOn(GetMarkersFromFiles, "default").mockResolvedValue({});
+            jest.spyOn(OutputCache, "outputCache").mockResolvedValue(
+                ExitCode.SUCCESS,
+            );
+
+            // Act
+            const result = await checkSync(
+                {
+                    includeGlobs: [],
+                    excludeGlobs: [],
+                    ignoreFiles: [],
+                    autoFix: false,
+                    comments: ["//"],
+                    dryRun: false,
+                    json: false,
+                    allowEmptyTags: false,
+                    cachePath: "",
+                    cacheMode: "write",
+                },
+                NullLogger,
+            );
+
+            // Assert
+            expect(result).toBe(ExitCode.SUCCESS);
+        });
     });
 });

--- a/src/__tests__/check-sync.test.ts
+++ b/src/__tests__/check-sync.test.ts
@@ -31,6 +31,8 @@ describe("#checkSync", () => {
                 comments: ["//"],
                 json: false,
                 allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
             },
             NullLogger,
         );
@@ -59,6 +61,8 @@ describe("#checkSync", () => {
                 comments: ["//"],
                 json: false,
                 allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
             },
             NullLogger,
         );
@@ -86,6 +90,8 @@ describe("#checkSync", () => {
             comments: ["//"],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -108,6 +114,8 @@ describe("#checkSync", () => {
             comments: ["//"],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -134,6 +142,8 @@ describe("#checkSync", () => {
             comments: ["//"],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -165,6 +175,8 @@ describe("#checkSync", () => {
             rootMarker: "marker",
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -197,6 +209,8 @@ describe("#checkSync", () => {
                 dryRun: false,
                 json: false,
                 allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
             },
             NullLogger,
         );

--- a/src/__tests__/default-options.test.ts
+++ b/src/__tests__/default-options.test.ts
@@ -30,6 +30,8 @@ describe("defaultOptions", () => {
 {
   "allowEmptyTags": false,
   "autoFix": false,
+  "cacheMode": "ignore",
+  "cachePath": "cache.json",
   "comments": [
     "#",
     "//",

--- a/src/__tests__/exit-error.test.ts
+++ b/src/__tests__/exit-error.test.ts
@@ -1,0 +1,88 @@
+import {ExitCode} from "../exit-codes";
+import {ExitError} from "../exit-error";
+
+describe("ExitError", () => {
+    it("should be an Error", () => {
+        // Arrange
+
+        // Act
+        const result = new ExitError("message", 1);
+
+        // Assert
+        expect(result).toBeInstanceOf(Error);
+    });
+
+    describe("message", () => {
+        it("should match the value passed ot the constructor", () => {
+            // Arrange
+            const message = "BOOM!";
+
+            // Act
+            const result = new ExitError(message, 1, {
+                cause: new Error("cause"),
+            });
+
+            // Assert
+            expect(result.message).toBe(message);
+        });
+    });
+
+    describe("cause", () => {
+        it("should match the value passed to the constructor", () => {
+            // Arrange
+            const cause = new Error("cause");
+
+            // Act
+            const result = new ExitError("message", 1, {cause});
+
+            // Assert
+            expect(result.cause).toBe(cause);
+        });
+    });
+
+    describe("name", () => {
+        it("should be 'ExitError'", () => {
+            // Arrange
+
+            // Act
+            const result = new ExitError("message", 1);
+
+            // Assert
+            expect(result.name).toBe("ExitError");
+        });
+    });
+
+    describe("exitCode", () => {
+        it.each`
+            code
+            ${ExitCode.CATASTROPHIC}
+            ${42 as ExitCode}
+        `(
+            "should match the exit code, $code, given in the constructor",
+            ({code}) => {
+                // Arrange
+
+                // Act
+                const result = new ExitError("message", code);
+
+                // Assert
+                expect(result.exitCode).toBe(code);
+            },
+        );
+    });
+
+    describe("toString", () => {
+        it("should return a string with the error name, message and exit code", () => {
+            // Arrange
+            const error = new ExitError("BOOM!", 42 as ExitCode);
+
+            // Act
+            const result = error.toString();
+
+            // Assert
+            expect(result).toMatchInlineSnapshot(
+                `"ExitError: BOOM! (Exit code: 42)"`,
+            );
+        });
+    });
+});

--- a/src/__tests__/fix-file.test.ts
+++ b/src/__tests__/fix-file.test.ts
@@ -39,6 +39,8 @@ describe("#fixFile", () => {
         rootMarker: null,
         json: false,
         allowEmptyTags: false,
+        cachePath: "",
+        cacheMode: "ignore",
     };
 
     it("should resolve if there are no mismatches for file", async () => {

--- a/src/__tests__/get-markers-from-files.test.ts
+++ b/src/__tests__/get-markers-from-files.test.ts
@@ -25,6 +25,8 @@ describe("#fromFiles", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -62,6 +64,8 @@ describe("#fromFiles", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -95,6 +99,8 @@ describe("#fromFiles", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -131,6 +137,8 @@ describe("#fromFiles", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -188,6 +196,8 @@ describe("#fromFiles", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -244,6 +254,8 @@ describe("#fromFiles", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -301,6 +313,8 @@ describe("#fromFiles", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -348,6 +362,8 @@ describe("#fromFiles", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act

--- a/src/__tests__/integration-test-support.test.ts
+++ b/src/__tests__/integration-test-support.test.ts
@@ -113,6 +113,25 @@ describe("integration-test-support", () => {
             );
         });
 
+        it("should run checksync in cache write mode for the given example", async () => {
+            // Arrange
+            const checkSyncSpy = jest
+                .spyOn(Checksync, "default")
+                .mockResolvedValueOnce(ExitCode.SUCCESS);
+
+            // Act
+            await runChecksync("example");
+
+            // Assert
+            expect(checkSyncSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    cachePath: expect.stringContaining("example.json"),
+                    cacheMode: "write",
+                }),
+                expect.any(StringLogger),
+            );
+        });
+
         it("should run checksync with the glob for the given example", async () => {
             // Arrange
             const checkSyncSpy = jest

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -10,7 +10,7 @@ describe("Integration Tests (see __examples__ folder)", () => {
     // For each example that we want to run for the current platform.
     describe.each(getExamples())("Example %s", (example) => {
         // For each scenario we want to cover
-        it.each(Object.values(Scenario))(
+        it.each([undefined, ...Object.values(Scenario)])(
             `should report example ${example} to match snapshot for scenario %s`,
             async (scenario) => {
                 const log = await readLog(example, scenario);

--- a/src/__tests__/load-cache.test.ts
+++ b/src/__tests__/load-cache.test.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises";
 import {loadCache} from "../load-cache";
 import {ExitCode} from "../exit-codes";
 import {ExitError} from "../exit-error";
+import {osSeparators} from "../normalize-separators";
 
 describe("loadCache", () => {
     it.each`
@@ -23,7 +24,7 @@ describe("loadCache", () => {
 
             // Assert
             expect(log.info).toHaveBeenCalledWith(
-                `Loading cache from /<rootDir>/cache.json`,
+                osSeparators(`Loading cache from /<rootDir>/cache.json`),
             );
         },
     );

--- a/src/__tests__/load-cache.test.ts
+++ b/src/__tests__/load-cache.test.ts
@@ -1,0 +1,114 @@
+import fs from "fs/promises";
+import {loadCache} from "../load-cache";
+import {ExitCode} from "../exit-codes";
+import {ExitError} from "../exit-error";
+
+describe("loadCache", () => {
+    it.each`
+        cachePath
+        ${"cache.json"}
+        ${"/<rootDir>/cache.json"}
+    `(
+        "should log the absolute cache file path for $cachePath",
+        async ({cachePath}) => {
+            // Arrange
+            const log = {
+                info: jest.fn(),
+            } as any;
+            jest.spyOn(process, "cwd").mockReturnValue("/<rootDir>");
+            jest.spyOn(fs, "readFile").mockResolvedValue("{}");
+
+            // Act
+            await loadCache(cachePath, log);
+
+            // Assert
+            expect(log.info).toHaveBeenCalledWith(
+                `Loading cache from /<rootDir>/cache.json`,
+            );
+        },
+    );
+
+    it("should load the cache file", async () => {
+        // Arrange
+        const log = {
+            info: jest.fn(),
+        } as any;
+        const readFileSpy = jest.spyOn(fs, "readFile").mockResolvedValue("{}");
+
+        // Act
+        await loadCache("/<rootDir>/cache.json", log);
+
+        // Assert
+        expect(readFileSpy).toHaveBeenCalledWith(
+            "/<rootDir>/cache.json",
+            "utf8",
+        );
+    });
+
+    it("should parse the JSON from the cache file", async () => {
+        // Arrange
+        const log = {
+            info: jest.fn(),
+        } as any;
+        jest.spyOn(fs, "readFile").mockResolvedValue('{"key":"value"}');
+        const jsonParseSpy = jest.spyOn(JSON, "parse");
+
+        // Act
+        await loadCache("/<rootDir>/cache.json", log);
+
+        // Assert
+        expect(jsonParseSpy).toHaveBeenCalledWith('{"key":"value"}');
+    });
+
+    it("should return the loaded JSON", async () => {
+        // Arrange
+        const log = {
+            info: jest.fn(),
+        } as any;
+        jest.spyOn(fs, "readFile").mockResolvedValue('{"key":"value"}');
+
+        // Act
+        const result = await loadCache("/<rootDir>/cache.json", log);
+
+        // Assert
+        expect(result).toEqual({key: "value"});
+    });
+
+    it("should throw BAD_CACHE exit error if the file cannot be loaded", async () => {
+        // Arrange
+        const log = {
+            info: jest.fn(),
+        } as any;
+        jest.spyOn(fs, "readFile").mockRejectedValue(
+            new Error("File not found"),
+        );
+
+        // Act
+        let error: ExitError | undefined;
+        await loadCache("/<rootDir>/cache.json", log).catch((e) => (error = e));
+
+        // Assert
+        expect(error?.message).toBe(
+            "Failed to load cache from /<rootDir>/cache.json",
+        );
+        expect(error?.exitCode).toBe(ExitCode.BAD_CACHE);
+    });
+
+    it("should throw BAD_CACHE exit error if the file cannot be parsed", async () => {
+        // Arrange
+        const log = {
+            info: jest.fn(),
+        } as any;
+        jest.spyOn(fs, "readFile").mockResolvedValue("invalid JSON");
+
+        // Act
+        let error: ExitError | undefined;
+        await loadCache("/<rootDir>/cache.json", log).catch((e) => (error = e));
+
+        // Assert
+        expect(error?.message).toBe(
+            "Failed to load cache from /<rootDir>/cache.json",
+        );
+        expect(error?.exitCode).toBe(ExitCode.BAD_CACHE);
+    });
+});

--- a/src/__tests__/load-cache.test.ts
+++ b/src/__tests__/load-cache.test.ts
@@ -8,7 +8,7 @@ describe("loadCache", () => {
     it.each`
         cachePath
         ${"cache.json"}
-        ${"/<rootDir>/cache.json"}
+        ${osSeparators("/<rootDir>/cache.json")}
     `(
         "should log the absolute cache file path for $cachePath",
         async ({cachePath}) => {

--- a/src/__tests__/options-from-args.test.ts
+++ b/src/__tests__/options-from-args.test.ts
@@ -278,4 +278,96 @@ describe("#optionsFromArgs", () => {
         // Assert
         expect(result.allowEmptyTags).toBe(false);
     });
+
+    it.each`
+        outputCache
+        ${""}
+        ${"CACHE_PATH"}
+    `(
+        "should set cacheMode as write if args.outputCache is $outputCache",
+        ({outputCache}) => {
+            // Arrange
+            const args: any = {
+                outputCache,
+            };
+
+            // Act
+            const result = optionsFromArgs(args);
+
+            // Assert
+            expect(result.cacheMode).toBe("write");
+        },
+    );
+
+    it.each`
+        fromCache
+        ${""}
+        ${"CACHE_PATH"}
+    `(
+        "should set cacheMode as read if args.fromCache is $fromCache",
+        ({fromCache}) => {
+            // Arrange
+            const args: any = {
+                fromCache,
+            };
+
+            // Act
+            const result = optionsFromArgs(args);
+
+            // Assert
+            expect(result.cacheMode).toBe("read");
+        },
+    );
+
+    it("should set cachePath to args.outputCache if args.outputCache is defined and not falsy", () => {
+        // Arrange
+        const args: any = {
+            outputCache: "CACHE_PATH",
+        };
+
+        // Act
+        const result = optionsFromArgs(args);
+
+        // Assert
+        expect(result.cachePath).toBe("CACHE_PATH");
+    });
+
+    it("should set cachePath to args.fromCache if args.fromCache is defined and not falsy", () => {
+        // Arrange
+        const args: any = {
+            fromCache: "CACHE_PATH",
+        };
+
+        // Act
+        const result = optionsFromArgs(args);
+
+        // Assert
+        expect(result.cachePath).toBe("CACHE_PATH");
+    });
+
+    it("should not set cachePath if args.outputCache is defined but falsy", () => {
+        // Arrange
+        const args: any = {
+            outputCache: "",
+        };
+
+        // Act
+        const result = optionsFromArgs(args);
+
+        // Assert
+        expect(result.cachePath).not.toBeDefined();
+    });
+
+    it("should not set cachePath if args.fromCache is defined but falsy", () => {
+        // Arrange
+        const args: any = {
+            fromCache: "",
+        };
+
+        // Act
+        const result = optionsFromArgs(args);
+
+        // Assert
+        expect(result.cachePath).not.toBeDefined();
+    });
 });

--- a/src/__tests__/output-cache.test.ts
+++ b/src/__tests__/output-cache.test.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises";
 import {outputCache} from "../output-cache";
 import {ExitCode} from "../exit-codes";
+import {osSeparators} from "../normalize-separators";
 
 describe("outputCache", () => {
     describe("with JSON flag", () => {
@@ -90,7 +91,7 @@ describe("outputCache", () => {
 
                 // Assert
                 expect(writeFileSpy).toHaveBeenCalledWith(
-                    "/<rootDir>/cache.json",
+                    osSeparators("/<rootDir>/cache.json"),
                     '{"foo":"bar"}',
                     "utf8",
                 );
@@ -120,7 +121,7 @@ describe("outputCache", () => {
 
                 // Assert
                 expect(log.info).toHaveBeenCalledWith(
-                    `Cache written to /<rootDir>/cache.json`,
+                    osSeparators(`Cache written to /<rootDir>/cache.json`),
                 );
             },
         );

--- a/src/__tests__/output-cache.test.ts
+++ b/src/__tests__/output-cache.test.ts
@@ -1,0 +1,170 @@
+import fs from "fs/promises";
+import {outputCache} from "../output-cache";
+import {ExitCode} from "../exit-codes";
+
+describe("outputCache", () => {
+    describe("with JSON flag", () => {
+        it("should log the JSON", async () => {
+            // Arrange
+            const log = {
+                log: jest.fn(),
+            } as any;
+
+            // Act
+            await outputCache(
+                {json: true, cacheMode: "write", cachePath: ""} as any,
+                {foo: "bar"} as any,
+                log,
+            );
+
+            // Assert
+            expect(log.log).toHaveBeenCalledWith('{"foo":"bar"}');
+        });
+
+        it("should log if an error occurs", async () => {
+            // Arrange
+            const log = {
+                log: jest.fn(),
+                error: jest.fn(),
+            } as any;
+            jest.spyOn(JSON, "stringify").mockImplementation(() => {
+                throw new Error("Unexpected error");
+            });
+
+            // Act
+            await outputCache(
+                {json: true, cacheMode: "write", cachePath: ""} as any,
+                null as any,
+                log,
+            );
+
+            // Assert
+            expect(log.error).toHaveBeenCalledWith("Unable to output cache");
+        });
+
+        it("should return CATASTROPHIC if an error occurs", async () => {
+            // Arrange
+            const log = {
+                log: jest.fn(),
+                error: jest.fn(),
+            } as any;
+            jest.spyOn(JSON, "stringify").mockImplementation(() => {
+                throw new Error("Unexpected error");
+            });
+
+            // Act
+            const result = await outputCache(
+                {json: true, cacheMode: "write", cachePath: ""} as any,
+                null as any,
+                log,
+            );
+
+            // Assert
+            expect(result).toBe(ExitCode.CATASTROPHIC);
+        });
+    });
+
+    describe("without JSON flag", () => {
+        it.each`
+            cachePath
+            ${"cache.json"}
+            ${"/<rootDir>/cache.json"}
+        `(
+            "should write the JSON to the absolute cache path of $cachePath",
+            async ({cachePath}) => {
+                // Arrange
+                const log = {
+                    info: jest.fn(),
+                } as any;
+                const writeFileSpy = jest
+                    .spyOn(fs, "writeFile")
+                    .mockResolvedValue();
+                jest.spyOn(process, "cwd").mockReturnValue("/<rootDir>");
+
+                // Act
+                await outputCache(
+                    {cacheMode: "write", cachePath} as any,
+                    {foo: "bar"} as any,
+                    log,
+                );
+
+                // Assert
+                expect(writeFileSpy).toHaveBeenCalledWith(
+                    "/<rootDir>/cache.json",
+                    '{"foo":"bar"}',
+                    "utf8",
+                );
+            },
+        );
+
+        it.each`
+            cachePath
+            ${"cache.json"}
+            ${"/<rootDir>/cache.json"}
+        `(
+            "should log that the cache has been written to the absolute cache path of $cachePath",
+            async ({cachePath}) => {
+                // Arrange
+                const log = {
+                    info: jest.fn(),
+                } as any;
+                jest.spyOn(fs, "writeFile").mockResolvedValue();
+                jest.spyOn(process, "cwd").mockReturnValue("/<rootDir>");
+
+                // Act
+                await outputCache(
+                    {cacheMode: "write", cachePath} as any,
+                    {foo: "bar"} as any,
+                    log,
+                );
+
+                // Assert
+                expect(log.info).toHaveBeenCalledWith(
+                    `Cache written to /<rootDir>/cache.json`,
+                );
+            },
+        );
+
+        it("should log if an unexpected error occurs", async () => {
+            // Arrange
+            const log = {
+                info: jest.fn(),
+                error: jest.fn(),
+            } as any;
+            jest.spyOn(fs, "writeFile").mockRejectedValue(
+                new Error("Unexpected"),
+            );
+
+            // Act
+            await outputCache(
+                {cacheMode: "write", cachePath: "/<rootDir>/cache.json"} as any,
+                {foo: "bar"} as any,
+                log,
+            );
+
+            // Assert
+            expect(log.error).toHaveBeenCalledWith("Unable to output cache");
+        });
+
+        it("should return CATASTROPHIC if an unexpected error occurs", async () => {
+            // Arrange
+            const log = {
+                info: jest.fn(),
+                error: jest.fn(),
+            } as any;
+            jest.spyOn(fs, "writeFile").mockRejectedValue(
+                new Error("Unexpected"),
+            );
+
+            // Act
+            const result = await outputCache(
+                {cacheMode: "write", cachePath: "/<rootDir>/cache.json"} as any,
+                {foo: "bar"} as any,
+                log,
+            );
+
+            // Assert
+            expect(result).toBe(ExitCode.CATASTROPHIC);
+        });
+    });
+});

--- a/src/__tests__/output-cache.test.ts
+++ b/src/__tests__/output-cache.test.ts
@@ -69,7 +69,7 @@ describe("outputCache", () => {
         it.each`
             cachePath
             ${"cache.json"}
-            ${"/<rootDir>/cache.json"}
+            ${osSeparators("/<rootDir>/cache.json")}
         `(
             "should write the JSON to the absolute cache path of $cachePath",
             async ({cachePath}) => {
@@ -101,7 +101,7 @@ describe("outputCache", () => {
         it.each`
             cachePath
             ${"cache.json"}
-            ${"/<rootDir>/cache.json"}
+            ${osSeparators("/<rootDir>/cache.json")}
         `(
             "should log that the cache has been written to the absolute cache path of $cachePath",
             async ({cachePath}) => {

--- a/src/__tests__/parse-file.test.ts
+++ b/src/__tests__/parse-file.test.ts
@@ -60,6 +60,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -84,6 +86,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -119,6 +123,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -151,6 +157,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -193,6 +201,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -232,6 +242,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -277,6 +289,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -356,6 +370,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -420,6 +436,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: true,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -481,6 +499,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -534,6 +554,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -585,6 +607,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
 
         // Act
@@ -629,6 +653,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -684,6 +710,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: true,
+            cachePath: "",
+            cacheMode: "ignore",
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -761,6 +789,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -819,6 +849,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -876,6 +908,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -982,6 +1016,8 @@ describe("#parseFile", () => {
             ignoreFiles: [],
             json: false,
             allowEmptyTags: false,
+            cachePath: "",
+            cacheMode: "ignore",
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];

--- a/src/build-cache.ts
+++ b/src/build-cache.ts
@@ -1,0 +1,29 @@
+import getMarkersFromFiles from "./get-markers-from-files";
+import getFiles from "./get-files";
+
+import {ILog, MarkerCache, Options} from "./types";
+import {ExitCode} from "./exit-codes";
+import {ExitError} from "./exit-error";
+
+/**
+ * Build a marker cache by parsing the files identified in options.
+ *
+ * @export
+ * @param options The options for this run
+ * @param log A logger for outputting errors and the like.
+ * @returns The promise of a marker cache.
+ * @throws ExitError if no files are found.
+ */
+export default async function buildCache(
+    options: Options,
+    log: ILog,
+): Promise<MarkerCache> {
+    const {includeGlobs, excludeGlobs, ignoreFiles} = options;
+    const files = await getFiles(includeGlobs, excludeGlobs, ignoreFiles, log);
+
+    if (files.length === 0) {
+        throw new ExitError("No matching files", ExitCode.NO_FILES);
+    }
+
+    return getMarkersFromFiles(options, files);
+}

--- a/src/check-sync.ts
+++ b/src/check-sync.ts
@@ -45,7 +45,7 @@ export default async function checkSync(
                 return ExitCode.BAD_CACHE;
             }
             if (error.exitCode === ExitCode.NO_FILES) {
-                log.error("No files found");
+                log.error("No matching files");
                 return ExitCode.NO_FILES;
             }
         }

--- a/src/check-sync.ts
+++ b/src/check-sync.ts
@@ -1,9 +1,11 @@
-import getMarkersFromFiles from "./get-markers-from-files";
-import getFiles from "./get-files";
 import {ExitCode} from "./exit-codes";
 import processCache from "./process-cache";
 
 import {ILog, Options} from "./types";
+import buildCache from "./build-cache";
+import {loadCache} from "./load-cache";
+import {ExitError} from "./exit-error";
+import {outputCache} from "./output-cache";
 
 /**
  *
@@ -18,19 +20,36 @@ export default async function checkSync(
     options: Options,
     log: ILog,
 ): Promise<ExitCode> {
-    if (options.autoFix && options.dryRun) {
+    // If the cacheMode is ignore, we just process the files normally.
+    // If the cacheMode is write, then we build the cache but we don't
+    // process it.
+    // If the cacheMode is read, then we read the cache and process that.
+    if (options.cacheMode !== "write" && options.autoFix && options.dryRun) {
         log.info("DRY-RUN: Files will not be modified");
     }
 
-    const {includeGlobs, excludeGlobs, ignoreFiles} = options;
-    const files = await getFiles(includeGlobs, excludeGlobs, ignoreFiles, log);
+    try {
+        const cache =
+            options.cacheMode === "read"
+                ? await loadCache(options.cachePath, log)
+                : await buildCache(options, log);
 
-    if (files.length === 0) {
-        log.error("No matching files");
-        return ExitCode.NO_FILES;
+        if (options.cacheMode === "write") {
+            return outputCache(options, cache, log);
+        }
+        return processCache(options, cache, log);
+    } catch (error) {
+        if (error instanceof ExitError) {
+            if (error.exitCode === ExitCode.BAD_CACHE) {
+                log.error("Unable to load cache");
+                return ExitCode.BAD_CACHE;
+            }
+            if (error.exitCode === ExitCode.NO_FILES) {
+                log.error("No files found");
+                return ExitCode.NO_FILES;
+            }
+        }
+        log.error("Unexpected catastrophic error");
+        return ExitCode.CATASTROPHIC;
     }
-
-    const cache = await getMarkersFromFiles(options, files);
-    const result = processCache(options, cache, log);
-    return result;
 }

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -10,6 +10,8 @@ const defaultOptions: Options = {
     // Make sure we have something to search, so default to current working
     // directory if no globs are given.
     includeGlobs: [`${process.cwd()}**`],
+    cachePath: "cache.json",
+    cacheMode: "ignore",
 };
 
 export default defaultOptions;

--- a/src/exit-codes.ts
+++ b/src/exit-codes.ts
@@ -9,4 +9,5 @@ export enum ExitCode {
     UNKNOWN_ARGS = 4,
     CATASTROPHIC = 5,
     BAD_CONFIG = 6,
+    BAD_CACHE = 7,
 }

--- a/src/exit-error.ts
+++ b/src/exit-error.ts
@@ -10,7 +10,7 @@ export class ExitError extends Error {
         this.exitCode = exitCode;
     }
 
-    exitCode: ExitCode;
+    readonly exitCode: ExitCode;
 
     toString(): string {
         return `${this.name}: ${this.message} (Exit code: ${this.exitCode})`;

--- a/src/exit-error.ts
+++ b/src/exit-error.ts
@@ -1,0 +1,18 @@
+import {ExitCode} from "./exit-codes";
+
+/**
+ * Error thrown to communicate an process exit condition.
+ */
+export class ExitError extends Error {
+    constructor(message: string, exitCode: ExitCode, options?: ErrorOptions) {
+        super(message, options);
+        this.name = "ExitError";
+        this.exitCode = exitCode;
+    }
+
+    exitCode: ExitCode;
+
+    toString(): string {
+        return `${this.name}: ${this.message} (Exit code: ${this.exitCode})`;
+    }
+}

--- a/src/load-cache.ts
+++ b/src/load-cache.ts
@@ -1,0 +1,35 @@
+import fs from "fs/promises";
+import {ILog, MarkerCache} from "./types";
+import {ExitError} from "./exit-error";
+import {ExitCode} from "./exit-codes";
+import path from "path";
+
+/**
+ * Load a marker cache from a file.
+ *
+ * @param filepath The path to the cache file.
+ * @param log A logger for outputting errors and the like.
+ * @returns A promise of a marker cache.
+ * @throws ExitError if the cache file cannot be read or parsed.
+ */
+export const loadCache = async (
+    filepath: string,
+    log: ILog,
+): Promise<MarkerCache> => {
+    const absCachePath = path.isAbsolute(filepath)
+        ? filepath
+        : path.join(process.cwd(), filepath);
+    try {
+        log.info(`Loading cache from ${absCachePath}`);
+        const cacheRaw = await fs.readFile(absCachePath, "utf8");
+        return JSON.parse(cacheRaw);
+    } catch (error) {
+        throw new ExitError(
+            `Failed to load cache from ${absCachePath}`,
+            ExitCode.BAD_CACHE,
+            {
+                cause: error,
+            },
+        );
+    }
+};

--- a/src/normalize-separators.ts
+++ b/src/normalize-separators.ts
@@ -7,4 +7,9 @@ import escapeRegExp from "lodash/escapeRegExp";
 const normalizeSeparators = (g: string): string =>
     g.replace(new RegExp(escapeRegExp(path.sep), "g"), "/");
 
+/**
+ * Normalize separators to the OS default.
+ */
+export const osSeparators = (g: string): string => g.replace(/\//g, path.sep);
+
 export default normalizeSeparators;

--- a/src/options-from-args.ts
+++ b/src/options-from-args.ts
@@ -53,5 +53,23 @@ export const optionsFromArgs = (args: Arguments<any>): Partial<Options> => {
         options.allowEmptyTags = !!args.allowEmptyTags;
     }
 
+    if (args.outputCache != null) {
+        // Only overwrite the path if one was given, otherwise we'll let
+        // defaults handle that.
+        if (args.outputCache) {
+            options.cachePath = args.outputCache;
+        }
+        options.cacheMode = "write";
+    }
+
+    if (args.fromCache != null) {
+        // Only overwrite the path if one was given, otherwise we'll let
+        // defaults handle that.
+        if (args.fromCache) {
+            options.cachePath = args.fromCache;
+        }
+        options.cacheMode = "read";
+    }
+
     return options;
 };

--- a/src/output-cache.ts
+++ b/src/output-cache.ts
@@ -1,0 +1,41 @@
+import fs from "fs/promises";
+import {ExitCode} from "./exit-codes";
+import {ExitError} from "./exit-error";
+import {ILog, MarkerCache, Options} from "./types";
+import path from "path";
+
+/**
+ * Write the cache to the output file or to the console.
+ *
+ * @param options The options for this run.
+ * @param cache The cache to write.
+ * @param log A logger for outputting errors and the like.
+ * @returns The promise of an error code.
+ * @throws ExitError if the cache file cannot be written.
+ */
+export const outputCache = async (
+    options: Options,
+    cache: MarkerCache,
+    log: ILog,
+): Promise<ExitCode> => {
+    try {
+        const cacheRaw = JSON.stringify(cache);
+        if (options.json) {
+            log.info(cacheRaw);
+        } else {
+            const absCachePath = path.isAbsolute(options.cachePath)
+                ? options.cachePath
+                : path.join(process.cwd(), options.cachePath);
+            await fs.writeFile(absCachePath, cacheRaw, "utf8");
+            log.info(`Cache written to ${absCachePath}`);
+        }
+        return ExitCode.SUCCESS;
+    } catch (error) {
+        if (error instanceof ExitError) {
+            log.error("Unable to write cache");
+            return error.exitCode;
+        }
+        log.error("Unexpected catastrophic error");
+        return ExitCode.CATASTROPHIC;
+    }
+};

--- a/src/output-cache.ts
+++ b/src/output-cache.ts
@@ -1,6 +1,5 @@
 import fs from "fs/promises";
 import {ExitCode} from "./exit-codes";
-import {ExitError} from "./exit-error";
 import {ILog, MarkerCache, Options} from "./types";
 import path from "path";
 
@@ -21,7 +20,7 @@ export const outputCache = async (
     try {
         const cacheRaw = JSON.stringify(cache);
         if (options.json) {
-            log.info(cacheRaw);
+            log.log(cacheRaw);
         } else {
             const absCachePath = path.isAbsolute(options.cachePath)
                 ? options.cachePath
@@ -31,11 +30,7 @@ export const outputCache = async (
         }
         return ExitCode.SUCCESS;
     } catch (error) {
-        if (error instanceof ExitError) {
-            log.error("Unable to write cache");
-            return error.exitCode;
-        }
-        log.error("Unexpected catastrophic error");
+        log.error("Unable to output cache");
         return ExitCode.CATASTROPHIC;
     }
 };

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -24,7 +24,25 @@ export const parseArgs = (log: ILog) =>
             "ignore",
             "ignoreFiles",
             "config",
+            "outputCache",
+            "fromCache",
         ])
+        .option("outputCache", {
+            type: "string",
+            description: "Path to the output cache file.",
+            conflicts: ["updateTags", "dryRun", "help", "version"],
+        })
+        .option("fromCache", {
+            type: "string",
+            description: "Path to the input cache file.",
+            conflicts: [
+                "comments",
+                "ignore",
+                "ignoreFiles",
+                "config",
+                "outputCache",
+            ],
+        })
         .alias("comments", ["c"])
         .alias("dryRun", ["n", "dry-run"])
         .alias("help", ["h", "?"])
@@ -34,6 +52,8 @@ export const parseArgs = (log: ILog) =>
         .alias("rootMarker", ["m", "root-marker"])
         .alias("updateTags", ["u", "update-tags"])
         .alias("allowEmptyTags", ["a", "allow-empty-tags"])
+        .alias("outputCache", ["o", "output-cache"])
+        .alias("fromCache", ["f", "use-cache"])
         .strictOptions()
         .fail((msg, err, yargs) => {
             log.error(msg);

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -1,3 +1,5 @@
+// We don't need coverage of this file...it's just yargs stuff.
+/* istanbul ignore file */
 import yargs from "yargs/yargs";
 import {hideBin} from "yargs/helpers";
 import {ExitCode} from "./exit-codes";

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,22 @@ export type Options = {
      * when true, a tag may be empty.
      */
     allowEmptyTags?: boolean;
+    /**
+     * The path to the cache file.
+     *
+     * This is only used if cacheMode is not "ignore".
+     */
+    cachePath: string;
+    /**
+     * The cache mode.
+     *
+     * When "write", all files are parsed and the cache is written to the
+     * given file.
+     *
+     * When "read", instead of parsing files, the cache file is read and used
+     * to produce the desired output.
+     */
+    cacheMode: "ignore" | "write" | "read";
 };
 
 export type NormalizedPathInfo = {


### PR DESCRIPTION
## Summary:
This adds some new arguments so that we can split out the parsing of tags (aka markers) from files, and the processing of the markers. This will speed up our integration tests, but potentially opens the door for other uses. For example, the upcoming migration tool could be run using a cache so that we can re-run it with the same cache without having to re-parse all the same files, which will make it easier for me to test against webapp's complex tagging without having to wait to parse all the files every time.

This is not some cache to speed up regular checksync usage (like, say, how babel uses a cache). That would take a lot more effort (like working out cache invalidation, etc.) and isn't planned at this time.

The output cache does not include the settings used to create it, so it should be run against the same config or CLI args as it was created.

Issue: FEI-6294 and closes #2039

## Test plan:
I have updated the integration tests to use this new mode so that we only do the parsing once per example, regardless of the scenarios. This should help with testing the migration tool that I'm working on to help move from the local sync tags to the remote sync tags where needed.

`pnpm test`