### PR TITLE
[fei6294.2.errorcodes] Move error creation to helper functions

### DIFF
--- a/.changeset/quiet-tigers-scream.md
+++ b/.changeset/quiet-tigers-scream.md
@@ -1,0 +1,5 @@
+---
+"checksync": patch
+---
+
+Rework error generation to make code a little more manageable

--- a/src/__tests__/generate-errors-for-file.test.ts
+++ b/src/__tests__/generate-errors-for-file.test.ts
@@ -143,7 +143,7 @@ describe("#generateMarkerEdges", () => {
                     text: "// sync-start:marker 1234 filea",
                     declaration: "// sync-start:marker WRONG filea",
                     description:
-                        "Updated checksum for sync-tag 'marker' referencing 'filea:1' from WRONG to 1234.",
+                        "Updated checksum for sync-tag 'marker' referencing 'filea:1' from wrong to 1234.",
                 },
             },
         ]);
@@ -715,7 +715,7 @@ describe("#generateMarkerEdges", () => {
                     text: "// sync-start:marker 1234 https://fileb",
                     declaration: "// sync-start:marker WRONG https://fileb",
                     description:
-                        "Updated checksum for sync-tag 'marker' referencing 'https://fileb' from WRONG to 1234.",
+                        "Updated checksum for sync-tag 'marker' referencing 'https://fileb' from wrong to 1234.",
                 },
             },
         ]);

--- a/src/__tests__/get-markers-from-files.test.ts
+++ b/src/__tests__/get-markers-from-files.test.ts
@@ -375,7 +375,7 @@ describe("#fromFiles", () => {
                 aliases: ["a.js"],
                 errors: [
                     {
-                        markerID: "MARKER_ID",
+                        markerID: null,
                         code: "could-not-parse",
                         reason: "Could not parse a.js: This isn't a file!",
                     },
@@ -387,7 +387,7 @@ describe("#fromFiles", () => {
                 aliases: ["b.js"],
                 errors: [
                     {
-                        markerID: "MARKER_ID",
+                        markerID: null,
                         code: "could-not-parse",
                         reason: "Could not parse b.js: This isn't a file!",
                     },

--- a/src/__tests__/parse-file.test.ts
+++ b/src/__tests__/parse-file.test.ts
@@ -98,7 +98,7 @@ describe("#parseFile", () => {
             {
                 markerID: null,
                 code: "could-not-parse",
-                reason: "Could not parse file: ERROR_STRING",
+                reason: "Could not parse root.path/file.js: ERROR_STRING",
             },
         ]);
     });
@@ -171,7 +171,7 @@ describe("#parseFile", () => {
                 {
                     markerID: null,
                     code: "could-not-parse",
-                    reason: "Could not parse file: ERROR_STRING",
+                    reason: "Could not parse root.path/file.js: ERROR_STRING",
                 },
             ],
             readOnly: false,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -242,13 +242,12 @@ export const noReturnTag = (
 /**
  * Create an error indicating a pending migration for missing local return tag.
  *
+ * @param options The options for the current run.
  * @param markerID The ID of the marker that is affected.
  * @param declaration The original declaration of the marker exhibiting the
  * mismatch.
  * @param line The line number where the marker is located.
- * @param currentCwdRelativeTargetPath The current path of the target tag.
- * @param currentRootRelativeTargetPath The current root-relative path of the
- * target tag.
+ * @param absoluteTargetPath The current path of the target tag.
  * @param migratedTarget The target to which the marker should be migrated.
  * @param incorrectChecksum The incorrect checksum.
  * @param correctChecksum The correct checksum.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,341 @@
+import cwdRelativePath from "./cwd-relative-path";
+import {ErrorCode} from "./error-codes";
+import normalizeSeparators from "./normalize-separators";
+import rootRelativePath from "./root-relative-path";
+import {ErrorDetails, Options} from "./types";
+
+/**
+ * Create an error indicating that the file could not be parsed.
+ *
+ * @param file The path of the file that could not be parsed.
+ * @param detail The reason why the file could not be parsed.
+ * @returns The error details.
+ */
+export const couldNotParse = (file: string, detail: string): ErrorDetails => ({
+    markerID: null,
+    code: ErrorCode.couldNotParse,
+    reason: `Could not parse ${file}: ${detail}`,
+});
+
+/**
+ * Create an error indicating that a different comment style is being used.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param line The line number where the marker is located.
+ * @returns The error details.
+ */
+export const differentCommentSyntax = (markerID: string, line: number) => ({
+    markerID,
+    reason: `Sync-start tags for '${markerID}' given in different comment styles. Please use the same style for all sync-start tags that have identical identifiers.`,
+    location: {line},
+    code: ErrorCode.differentCommentSyntax,
+});
+
+/**
+ * Create an error indicating a duplicate marker declaration.
+ *
+ * @param markerID The ID of the marker that is duplicated.
+ * @param line The line number where the marker is located.
+ * @returns The error details.
+ */
+export const duplicateMarker = (
+    markerID: string,
+    line: number,
+): ErrorDetails => ({
+    markerID,
+    reason: `Sync-tag '${markerID}' declared multiple times`,
+    location: {line},
+    code: ErrorCode.duplicateMarker,
+});
+
+/**
+ * Create an error indicating a duplicate target for a marker.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param line The line number where the marker is located.
+ * @param declaration The declaration of the duplicate target.
+ * @returns The error details.
+ */
+export const duplicateTarget = (
+    markerID: string,
+    line: number,
+    declaration: string,
+): ErrorDetails => ({
+    markerID,
+    reason: `Duplicate target for sync-tag '${markerID}'`,
+    location: {line},
+    code: ErrorCode.duplicateTarget,
+    fix: {
+        type: "delete",
+        description: `Removed duplicate target for sync-tag '${markerID}'`,
+        declaration,
+        line,
+    },
+});
+
+/**
+ * Create an error indicating an empty marker.
+ *
+ * @param markerID The ID of the marker that is empty.
+ * @param line The line number where the marker is located.
+ * @returns The error details.
+ */
+export const emptyMarker = (markerID: string, line: number): ErrorDetails => ({
+    markerID,
+    reason: `Sync-tag '${markerID}' has no content`,
+    location: {line},
+    code: ErrorCode.emptyMarker,
+});
+
+/**
+ * Create an error indicating an end tag was found with no start tag.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param line The line number where the marker is located.
+ * @returns The error details.
+ */
+export const endTagWithoutStartTag = (
+    markerID: string,
+    line: number,
+): ErrorDetails => ({
+    markerID,
+    reason: `Sync-end for '${markerID}' found, but there was no corresponding sync-start`,
+    location: {line},
+    code: ErrorCode.endTagWithoutStartTag,
+});
+
+/**
+ * Create an error indicating a file for a target does not exist.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param line The line number where the marker is located.
+ * @param normalizedTargetPath The normalized path of the target file.
+ */
+export const fileDoesNotExist = (
+    markerID: string,
+    line: number,
+    targetPath: string,
+): ErrorDetails => ({
+    markerID,
+    reason: `Sync-start for '${markerID}' points to '${targetPath}', which does not exist or is a directory`,
+    location: {line},
+    code: ErrorCode.fileDoesNotExist,
+});
+
+/**
+ * Create an error indicating a malformed sync-end tag.
+ *
+ * @param line The line number where the malformed tag is located.
+ * @returns The error details.
+ */
+export const malformedEndTag = (line: number): ErrorDetails => ({
+    markerID: null,
+    reason: `Malformed sync-end: format should be 'sync-end:<label>'`,
+    location: {line},
+    code: ErrorCode.malformedEndTag,
+});
+
+/**
+ * Create an error indicating a malformed sync-start tag.
+ *
+ * @param line The line number where the malformed tag is located.
+ * @returns The error details.
+ */
+export const malformedStartTag = (line: number): ErrorDetails => ({
+    markerID: null,
+    reason: `Malformed sync-start: format should be 'sync-start:<label> [checksum] <filename> <optional_comment_end>'`,
+    location: {line},
+    code: ErrorCode.malformedStartTag,
+});
+
+/**
+ * Create an error indicating a mismatched checksum for a locally targeted tag.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param declaration The original declaration of the marker exhibiting the
+ * mismatch.
+ * @param targetPath The path of the target tag.
+ * @param targetLine The line number where the marker is located.
+ * @param lineToBeFixed The line number where the fix should be applied.
+ * @param incorrectChecksum The incorrect checksum.
+ * @param correctChecksum The correct checksum.
+ * @param fixedTag The fixed tag that should replace the mismatched one.
+ */
+export const mismatchedChecksumForLocalTarget = (
+    markerID: string,
+    declaration: string,
+    targetPath: string,
+    targetLine: number,
+    lineToBeFixed: number,
+    incorrectChecksum: string,
+    correctChecksum: string,
+    fixedTag: string,
+): ErrorDetails => ({
+    markerID,
+    code: ErrorCode.mismatchedChecksum,
+    reason: `Looks like you changed the target content for sync-tag '${markerID}' in '${targetPath}:${
+        targetLine
+    }'. Make sure you've made corresponding changes in the source file, if necessary (${incorrectChecksum} != ${correctChecksum})`,
+    location: {line: targetLine},
+    fix: {
+        type: "replace",
+        line: lineToBeFixed,
+        text: fixedTag,
+        declaration,
+        description: `Updated checksum for sync-tag '${markerID}' referencing '${targetPath}:${targetLine}' from ${incorrectChecksum.toLowerCase()} to ${correctChecksum}.`,
+    },
+});
+
+/**
+ * Create an error indicating a mismatched checksum for a remotely targeted tag.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param declaration The original declaration of the marker exhibiting the
+ * mismatch.
+ * @param targetPath The path of the target tag.
+ * @param line The line number where the marker is located.
+ * @param incorrectChecksum The incorrect checksum.
+ * @param correctChecksum The correct checksum.
+ * @param fixedTag The fixed tag that should replace the mismatched one.
+ */
+export const mismatchedChecksumForRemoteTarget = (
+    markerID: string,
+    declaration: string,
+    targetPath: string,
+    line: number,
+    incorrectChecksum: string,
+    correctChecksum: string,
+    fixedTag: string,
+): ErrorDetails => ({
+    markerID,
+    code: ErrorCode.mismatchedChecksum,
+    reason: `Looks like you changed the content of sync-tag '${markerID}' or the path of the file that contains the tag. Make sure you've made corresponding changes at ${targetPath}, if necessary (${incorrectChecksum} != ${correctChecksum})`,
+    location: {line},
+    fix: {
+        type: "replace",
+        line,
+        text: fixedTag,
+        declaration,
+        description: `Updated checksum for sync-tag '${markerID}' referencing '${targetPath}' from ${incorrectChecksum.toLowerCase()} to ${correctChecksum}.`,
+    },
+});
+
+/**
+ * Create an error indicating the target does not have a return tag.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param line The line number where the marker is located.
+ * @param targetPath The path of the target that should have the return tag.
+ * @returns The error details.
+ */
+export const noReturnTag = (
+    markerID: string,
+    line: number,
+    targetPath: string,
+): ErrorDetails => ({
+    markerID,
+    reason: `No return tag named '${markerID}' in '${targetPath}'`,
+    code: ErrorCode.noReturnTag,
+    location: {line},
+});
+
+/**
+ * Create an error indicating a pending migration for missing local return tag.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param declaration The original declaration of the marker exhibiting the
+ * mismatch.
+ * @param line The line number where the marker is located.
+ * @param currentCwdRelativeTargetPath The current path of the target tag.
+ * @param currentRootRelativeTargetPath The current root-relative path of the
+ * target tag.
+ * @param migratedTarget The target to which the marker should be migrated.
+ * @param incorrectChecksum The incorrect checksum.
+ * @param correctChecksum The correct checksum.
+ * @param fixedTag The fixed tag that should replace the mismatched one.
+ * @returns The error details.
+ */
+export const pendingMigrationForMissingTarget = (
+    options: Options,
+    markerID: string,
+    declaration: string,
+    line: number,
+    absoluteTargetPath: string,
+    migratedTarget: string,
+    incorrectChecksum: string,
+    correctChecksum: string,
+    fixedTag: string,
+): ErrorDetails => {
+    const currentCwdRelativeTargetPath = cwdRelativePath(absoluteTargetPath);
+    const currentRootRelativeTargetPath = normalizeSeparators(
+        rootRelativePath(absoluteTargetPath, options.rootMarker),
+    );
+    return {
+        markerID,
+        reason: `No return tag named '${markerID}' in '${currentCwdRelativeTargetPath}'. Recommend migration to remote target '${migratedTarget}' and update checksum to ${correctChecksum}.`,
+        code: ErrorCode.pendingMigration,
+        location: {line},
+        fix: {
+            type: "replace",
+            line,
+            text: fixedTag,
+            declaration,
+            description: `Migrated sync-tag '${markerID}'. Target changed from '${currentRootRelativeTargetPath}' to '${migratedTarget}'. Checksum updated from ${incorrectChecksum.toLowerCase()} to ${correctChecksum}`,
+        },
+    };
+};
+
+/**
+ * Create an error indicating a marker that targets itself.
+ *
+ * @param markerID The ID of the marker that targets itself.
+ * @param line The line number where the marker is located.
+ * @returns The error details.
+ */
+export const selfTargeting = (
+    markerID: string,
+    line: number,
+): ErrorDetails => ({
+    markerID,
+    reason: `Sync-tag '${markerID}' cannot target itself`,
+    location: {line},
+    code: ErrorCode.selfTargeting,
+});
+
+/**
+ * Create an error indicating a marker found after the content already started.
+ *
+ * This is for when a start tag for a marker with the given ID has already
+ * been parsed and we're in the middle of parsing the content, when we find
+ * another start tag for that same marker.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param line The line number where the marker is located.
+ * @returns The error details.
+ */
+export const startTagAfterContent = (
+    markerID: string,
+    line: number,
+): ErrorDetails => ({
+    markerID,
+    reason: `Sync-start for '${markerID}' found after content started`,
+    location: {line},
+    code: ErrorCode.startTagAfterContent,
+});
+
+/**
+ * Create an error indicating a start tag was found with no end tag.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param line The line number where the marker is located.
+ * @returns The error details.
+ */
+export const startTagWithoutEndTag = (
+    markerID: string,
+    line: number,
+): ErrorDetails => ({
+    markerID,
+    reason: `Sync-start '${markerID}' has no corresponding sync-end`,
+    location: {line},
+    code: ErrorCode.startTagWithoutEndTag,
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -154,7 +154,7 @@ export const malformedStartTag = (line: number): ErrorDetails => ({
  * @param markerID The ID of the marker that is affected.
  * @param declaration The original declaration of the marker exhibiting the
  * mismatch.
- * @param targetPath The path of the target tag.
+ * @param absoluteTargetPath The path of the target tag.
  * @param targetLine The line number where the marker is located.
  * @param lineToBeFixed The line number where the fix should be applied.
  * @param incorrectChecksum The incorrect checksum.
@@ -164,27 +164,30 @@ export const malformedStartTag = (line: number): ErrorDetails => ({
 export const mismatchedChecksumForLocalTarget = (
     markerID: string,
     declaration: string,
-    targetPath: string,
+    absoluteTargetPath: string,
     targetLine: number,
     lineToBeFixed: number,
     incorrectChecksum: string,
     correctChecksum: string,
     fixedTag: string,
-): ErrorDetails => ({
-    markerID,
-    code: ErrorCode.mismatchedChecksum,
-    reason: `Looks like you changed the target content for sync-tag '${markerID}' in '${targetPath}:${
-        targetLine
-    }'. Make sure you've made corresponding changes in the source file, if necessary (${incorrectChecksum} != ${correctChecksum})`,
-    location: {line: targetLine},
-    fix: {
-        type: "replace",
-        line: lineToBeFixed,
-        text: fixedTag,
-        declaration,
-        description: `Updated checksum for sync-tag '${markerID}' referencing '${targetPath}:${targetLine}' from ${incorrectChecksum.toLowerCase()} to ${correctChecksum}.`,
-    },
-});
+): ErrorDetails => {
+    const currentCwdRelativeTargetPath = cwdRelativePath(absoluteTargetPath);
+    return {
+        markerID,
+        code: ErrorCode.mismatchedChecksum,
+        reason: `Looks like you changed the target content for sync-tag '${markerID}' in '${currentCwdRelativeTargetPath}:${
+            targetLine
+        }'. Make sure you've made corresponding changes in the source file, if necessary (${incorrectChecksum} != ${correctChecksum})`,
+        location: {line: targetLine},
+        fix: {
+            type: "replace",
+            line: lineToBeFixed,
+            text: fixedTag,
+            declaration,
+            description: `Updated checksum for sync-tag '${markerID}' referencing '${currentCwdRelativeTargetPath}:${targetLine}' from ${incorrectChecksum.toLowerCase()} to ${correctChecksum}.`,
+        },
+    };
+};
 
 /**
  * Create an error indicating a mismatched checksum for a remotely targeted tag.

--- a/src/fix-file.ts
+++ b/src/fix-file.ts
@@ -9,7 +9,6 @@ import {
 } from "./types";
 
 const reportFix = (
-    sourceFile: string,
     fix: FixAction | null | undefined,
     log: IPositionLog,
 ): void => {
@@ -92,7 +91,7 @@ export default function fixFile(
                 lineNumber++;
 
                 // Report the fix.
-                reportFix(file, fix, log);
+                reportFix(fix, log);
 
                 // TODO: Determine actual file line-ending and use that rather
                 // than assuming \n like we do here.

--- a/src/format-sync-tag-start.ts
+++ b/src/format-sync-tag-start.ts
@@ -1,0 +1,22 @@
+/**
+ * Create a sync tag start string.
+ *
+ * This does not include indentation. Callers are responsible for adding any
+ * necessary indentation.
+ *
+ * @param markerID The ID of the marker.
+ * @param commentStart The comment start string.
+ * @param commentEnd The comment end string.
+ * @param checksum The checksum.
+ * @param target The target the sync tag points to.
+ * @returns The formatted sync tag start string, without indentation.
+ */
+export const formatSyncTagStart = (
+    markerID: string,
+    commentStart: string,
+    commentEnd: string | undefined | null,
+    checksum: string,
+    target: string,
+): string => {
+    return `${commentStart} sync-start:${markerID} ${checksum} ${target}${commentEnd || ""}`;
+};

--- a/src/generate-errors-for-file.ts
+++ b/src/generate-errors-for-file.ts
@@ -104,10 +104,6 @@ export default function* generateErrors(
                     continue;
                 }
 
-                const normalizedTargetRef = normalizeSeparators(
-                    sourceRef.target,
-                );
-
                 if (targetDetails?.line == null || targetChecksum == null) {
                     // This is a missing return tag.
                     // Can be because the target file doesn't exist or there's
@@ -150,7 +146,7 @@ export default function* generateErrors(
                 yield Errors.mismatchedChecksumForLocalTarget(
                     markerID,
                     sourceRef.declaration,
-                    cwdRelativePath(normalizedTargetRef),
+                    sourceRef.target,
                     targetDetails.line,
                     sourceLine,
                     currentChecksum || NoChecksum,
@@ -160,9 +156,11 @@ export default function* generateErrors(
                         sourceMarker.commentStart,
                         sourceMarker.commentEnd,
                         targetChecksum,
-                        rootRelativePath(
-                            normalizedTargetRef,
-                            options.rootMarker,
+                        normalizeSeparators(
+                            rootRelativePath(
+                                sourceRef.target,
+                                options.rootMarker,
+                            ),
                         ),
                     )}`,
                 );

--- a/src/get-markers-from-files.ts
+++ b/src/get-markers-from-files.ts
@@ -5,7 +5,7 @@ import fs from "fs";
 import parseFile from "./parse-file";
 
 import {FileInfo, MarkerCache, Options} from "./types";
-import {ErrorCode} from "./error-codes";
+import * as Errors from "./errors";
 
 /**
  * Generate a marker cache from the given files.
@@ -79,13 +79,7 @@ export default async function getMarkersFromFiles(
                     readOnly,
                     markers: {},
                     aliases: [],
-                    errors: [
-                        {
-                            markerID: "MARKER_ID",
-                            code: ErrorCode.couldNotParse,
-                            reason: `Could not parse ${file}: ${e.message}`,
-                        },
-                    ],
+                    errors: [Errors.couldNotParse(file, e.message)],
                 });
             }
         }


### PR DESCRIPTION
## Summary:
This is a tidy-up task before I add the last bit of migration stuff. It isn't perfect but it moves the error creation to helper functions to make things a little more consistent and help spot patterns.

Trying to work out the smallest set of args to send was a little trying so I didn't try too hard on this pass. I expect a bigger refactor will be needed to make this nicer; such as not including full text messages in the details but letting those be calculated at a later stage. Some clear areas of confusion are around when a target path is used for the tag itself (needs to be relative to the root marker), or when it is used to report to the user (needs to be relative to the current working directory).

Issue: FEI-6294

## Test plan:
`pnpm test` to show that things are good.