### PR TITLE
[fei6294.3.modeall] Implement migrate all mode

### DIFF
--- a/.changeset/public-beers-dance.md
+++ b/.changeset/public-beers-dance.md
@@ -1,0 +1,5 @@
+---
+"checksync": major
+---
+
+Add support for migrating any tag that matches a migration rule

--- a/.checksyncrc.json
+++ b/.checksyncrc.json
@@ -26,7 +26,7 @@
             {
                 "to": "https://example.com/2/",
                 "from": [
-                    "__examples__/migrate_existing_target/",
+                    "__examples__/migrate_all/",
                     "__examples__/migrate_missing_target/subfolder/"
                 ]
             }

--- a/__examples__/migrate_all/example-1.js
+++ b/__examples__/migrate_all/example-1.js
@@ -1,0 +1,6 @@
+// This is a a javascript (or similar language) file
+
+// sync-start:migrate_all 12345 __examples__/migrate_all/example-2.js
+const someCode = "does a thing";
+console.log(someCode);
+// sync-end:migrate_all

--- a/__examples__/migrate_all/example-2.js
+++ b/__examples__/migrate_all/example-2.js
@@ -1,0 +1,6 @@
+// This is a a javascript (or similar language) file
+
+// sync-start:migrate_all 12345 __examples__/migrate_all/example-1.js
+const someCode = "does a thing";
+console.log(someCode);
+// sync-end:migrate_all

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,9 +25,5 @@ module.exports = {
 
     prettierPath: null,
 
-    setupFilesAfterEnv: [
-        "jest-extended/all",
-        "./jest.setup.js",
-        "./src/polyfills.ts",
-    ],
+    setupFilesAfterEnv: ["jest-extended/all", "./jest.setup.js"],
 };

--- a/package.json
+++ b/package.json
@@ -114,8 +114,5 @@
         "publish:ci": "git diff --stat --exit-code HEAD && pnpm build && changeset publish",
         "env": "node"
     },
-    "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b",
-    "dependencies": {
-        "es-iterator-helpers": "^1.2.1"
-    }
+    "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      es-iterator-helpers:
-        specifier: ^1.2.1
-        version: 1.2.1
     devDependencies:
       '@babel/cli':
         specifier: ^7.24.7

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -36,7 +36,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -63,7 +68,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -124,7 +134,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -151,7 +166,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/checksums_need_updating.json
@@ -209,7 +229,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -236,7 +261,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/checksums_need_updating.json
@@ -348,7 +378,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -375,7 +410,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -432,7 +472,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -459,7 +504,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -523,7 +573,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -550,7 +605,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/content_after_start.json
@@ -616,7 +676,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -643,7 +708,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/content_after_start.json
@@ -772,7 +842,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -799,7 +874,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -856,7 +936,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -883,7 +968,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -925,7 +1015,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -952,7 +1047,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/correct_checksums.json
@@ -994,7 +1094,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1021,7 +1126,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/correct_checksums.json
@@ -1066,7 +1176,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1093,7 +1208,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -1150,7 +1270,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1177,7 +1302,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -1226,7 +1356,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1253,7 +1388,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/directory_target.json
@@ -1302,7 +1442,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1329,7 +1474,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/directory_target.json
@@ -1394,7 +1544,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1421,7 +1576,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -1477,7 +1637,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1504,7 +1669,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -1561,7 +1731,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1588,7 +1763,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/duplicate_target.json
@@ -1645,7 +1825,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1672,7 +1857,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/duplicate_target.json
@@ -1781,7 +1971,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1808,7 +2003,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -1864,7 +2064,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1891,7 +2096,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -1938,7 +2148,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -1965,7 +2180,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/empty_tag.json
@@ -2012,7 +2232,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2039,7 +2264,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/empty_tag.json
@@ -2096,7 +2326,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2123,7 +2358,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -2179,7 +2419,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2206,7 +2451,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -2253,7 +2503,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2280,7 +2535,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/end_with_no_start.json
@@ -2327,7 +2587,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2354,7 +2619,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/end_with_no_start.json
@@ -2411,7 +2681,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2438,7 +2713,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -2493,7 +2773,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2520,7 +2805,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -2562,7 +2852,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2589,7 +2884,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/excluded.json
@@ -2631,7 +2931,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2658,7 +2963,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/excluded.json
@@ -2699,7 +3009,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2726,7 +3041,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -2779,7 +3099,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2806,7 +3131,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -2853,7 +3183,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2880,7 +3215,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json
@@ -2927,7 +3267,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -2954,7 +3299,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json
@@ -3011,7 +3361,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3038,7 +3393,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -3100,7 +3460,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3127,7 +3492,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -3181,7 +3551,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3208,7 +3583,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/malformed_end.json
@@ -3262,7 +3642,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3289,7 +3674,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/malformed_end.json
@@ -3372,7 +3762,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3399,7 +3794,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -3455,7 +3855,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3482,7 +3887,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -3541,7 +3951,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3568,7 +3983,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/malformed_start.json
@@ -3627,7 +4047,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3654,7 +4079,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/malformed_start.json
@@ -3755,7 +4185,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3782,7 +4217,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -3801,6 +4241,397 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/malformed_start/malformed_onlytagid.js"
 ]
 Info     Cache written to ROOT_DIR/.integrationtests/malformed_start.json"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example migrate_all should report example migrate_all to match snapshot for scenario autofix 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/migrate_all/**"
+  ],
+  "autoFix": true,
+  "dryRun": true,
+  "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
+  "cacheMode": "read"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false,
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/migrate_all/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
+  "cacheMode": "read",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Info     DRY-RUN: Files will not be modified
+Info     Loading cache from ROOT_DIR/.integrationtests/migrate_all.json
+Verbose  __examples__/migrate_all/example-1.js
+File has errors; skipping auto-fix
+Fix      __examples__/migrate_all/example-1.js:3
+Updated checksum for sync-tag 'migrate_all' referencing '__examples__/migrate_all/example-2.js:3' from 12345 to 770446101.
+Verbose  __examples__/migrate_all/example-2.js
+File has errors; skipping auto-fix
+Fix      __examples__/migrate_all/example-2.js:3
+Updated checksum for sync-tag 'migrate_all' referencing '__examples__/migrate_all/example-1.js:3' from 12345 to 770446101.
+
+<group 2 file(s) would have been fixed.
+To fix, run: >
+  checksync -u __examples__/migrate_all/example-1.js __examples__/migrate_all/example-2.js
+<end_group>
+🎉  Everything is in sync!"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example migrate_all should report example migrate_all to match snapshot for scenario check-only 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/migrate_all/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
+  "cacheMode": "read"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false,
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/migrate_all/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
+  "cacheMode": "read",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Info     Loading cache from ROOT_DIR/.integrationtests/migrate_all.json
+Mismatch __examples__/migrate_all/example-1.js:3
+Looks like you changed the target content for sync-tag 'migrate_all' in '__examples__/migrate_all/example-2.js:3'
+Make sure you've made corresponding changes in the source file, if necessary (12345 != 770446101)
+Mismatch __examples__/migrate_all/example-2.js:3
+Looks like you changed the target content for sync-tag 'migrate_all' in '__examples__/migrate_all/example-1.js:3'
+Make sure you've made corresponding changes in the source file, if necessary (12345 != 770446101)
+
+<group 🛠  Desynchronized blocks detected. Check them and update as required before resynchronizing: >
+
+  checksync -u __examples__/migrate_all/example-1.js __examples__/migrate_all/example-2.js
+<end_group>"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example migrate_all should report example migrate_all to match snapshot for scenario json-check-only 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/migrate_all/**"
+  ],
+  "json": true,
+  "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
+  "cacheMode": "read"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false,
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/migrate_all/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
+  "cacheMode": "read",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Info     Loading cache from ROOT_DIR/.integrationtests/migrate_all.json
+{
+    "version": "0.0.0",
+    "launchString": "checksync -u __examples__/migrate_all/example-1.js __examples__/migrate_all/example-2.js",
+    "files": {
+        "__examples__/migrate_all/example-1.js": [
+            {
+                "markerID": "migrate_all",
+                "code": "mismatched-checksum",
+                "reason": "Looks like you changed the target content for sync-tag 'migrate_all' in '__examples__/migrate_all/example-2.js:3'. Make sure you've made corresponding changes in the source file, if necessary (12345 != 770446101)",
+                "location": {
+                    "line": 3
+                },
+                "fix": {
+                    "type": "replace",
+                    "line": 3,
+                    "text": "// sync-start:migrate_all 770446101 __examples__/migrate_all/example-2.js",
+                    "declaration": "// sync-start:migrate_all 12345 __examples__/migrate_all/example-2.js",
+                    "description": "Updated checksum for sync-tag 'migrate_all' referencing '__examples__/migrate_all/example-2.js:3' from 12345 to 770446101."
+                }
+            }
+        ],
+        "__examples__/migrate_all/example-2.js": [
+            {
+                "markerID": "migrate_all",
+                "code": "mismatched-checksum",
+                "reason": "Looks like you changed the target content for sync-tag 'migrate_all' in '__examples__/migrate_all/example-1.js:3'. Make sure you've made corresponding changes in the source file, if necessary (12345 != 770446101)",
+                "location": {
+                    "line": 3
+                },
+                "fix": {
+                    "type": "replace",
+                    "line": 3,
+                    "text": "// sync-start:migrate_all 770446101 __examples__/migrate_all/example-1.js",
+                    "declaration": "// sync-start:migrate_all 12345 __examples__/migrate_all/example-1.js",
+                    "description": "Updated checksum for sync-tag 'migrate_all' referencing '__examples__/migrate_all/example-1.js:3' from 12345 to 770446101."
+                }
+            }
+        ]
+    }
+}"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example migrate_all should report example migrate_all to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/migrate_all/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false,
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/migrate_all/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
+  "cacheMode": "write",
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/migrate_all/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/migrate_all/example-1.js",
+    "ROOT_DIR/__examples__/migrate_all/example-2.js"
+]
+Info     Cache written to ROOT_DIR/.integrationtests/migrate_all.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example migrate_missing_target should report example migrate_missing_target to match snapshot for scenario autofix 1`] = `
@@ -3839,7 +4670,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3866,7 +4702,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -3923,7 +4764,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -3950,7 +4796,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/migrate_missing_target.json
@@ -4002,7 +4853,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4029,7 +4885,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/migrate_missing_target.json
@@ -4107,7 +4968,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4134,7 +5000,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -4189,7 +5060,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4216,7 +5092,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -4265,7 +5146,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4292,7 +5178,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/missing_target.json
@@ -4341,7 +5232,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4368,7 +5264,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/missing_target.json
@@ -4433,7 +5334,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4460,7 +5366,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -4515,7 +5426,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4542,7 +5458,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -4589,7 +5510,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4616,7 +5542,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/no_back_reference.json
@@ -4663,7 +5594,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4690,7 +5626,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/no_back_reference.json
@@ -4747,7 +5688,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4774,7 +5720,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -4830,7 +5781,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4857,7 +5813,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -4912,7 +5873,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -4939,7 +5905,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/no_checksums.json
@@ -4991,7 +5962,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5018,7 +5994,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/no_checksums.json
@@ -5098,7 +6079,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5125,7 +6111,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -5181,7 +6172,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5208,7 +6204,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -5260,7 +6261,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5287,7 +6293,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/no_self_reference.json
@@ -5342,7 +6353,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5369,7 +6385,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/no_self_reference.json
@@ -5441,7 +6462,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5468,7 +6494,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -5523,7 +6554,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5550,7 +6586,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -5601,7 +6642,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5628,7 +6674,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/remote_tags_broken.json
@@ -5677,7 +6728,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5704,7 +6760,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/remote_tags_broken.json
@@ -5767,7 +6828,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5794,7 +6860,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -5849,7 +6920,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5876,7 +6952,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -5918,7 +6999,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -5945,7 +7031,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/remote_tags_match.json
@@ -5987,7 +7078,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -6014,7 +7110,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/remote_tags_match.json
@@ -6059,7 +7160,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -6086,7 +7192,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [
@@ -6141,7 +7252,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -6168,7 +7284,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     DRY-RUN: Files will not be modified
@@ -6218,7 +7339,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -6245,7 +7371,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/unterminated_marker.json
@@ -6295,7 +7426,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -6322,7 +7458,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/unterminated_marker.json
@@ -6389,7 +7530,12 @@ Verbose  Options from config: {
   ],
   "json": false,
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Combined options with defaults: {
@@ -6416,7 +7562,12 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mappings": {}
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
   }
 }
 Verbose  Ignore files: [

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -4251,7 +4251,11 @@ exports[`Integration Tests (see __examples__ folder) Example migrate_all should 
   "autoFix": true,
   "dryRun": true,
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
-  "cacheMode": "read"
+  "cacheMode": "read",
+  "migration": {
+    "mode": "all",
+    "mappings": {}
+  }
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4311,7 +4315,7 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mode": "missing",
+    "mode": "all",
     "mappings": {
       "__examples__/migrate_missing_target/": "https://example.com/1/",
       "__examples__/migrate_all/": "https://example.com/2/",
@@ -4324,11 +4328,15 @@ Info     Loading cache from ROOT_DIR/.integrationtests/migrate_all.json
 Verbose  __examples__/migrate_all/example-1.js
 File has errors; skipping auto-fix
 Fix      __examples__/migrate_all/example-1.js:3
-Updated checksum for sync-tag 'migrate_all' referencing '__examples__/migrate_all/example-2.js:3' from 12345 to 770446101.
+Migrated sync-tag 'migrate_all'
+Target changed from '__examples__/migrate_all/example-2.js' to 'https://example.com/2/example-2.js'
+Checksum updated from 12345 to 60104996
 Verbose  __examples__/migrate_all/example-2.js
 File has errors; skipping auto-fix
 Fix      __examples__/migrate_all/example-2.js:3
-Updated checksum for sync-tag 'migrate_all' referencing '__examples__/migrate_all/example-1.js:3' from 12345 to 770446101.
+Migrated sync-tag 'migrate_all'
+Target changed from '__examples__/migrate_all/example-1.js' to 'https://example.com/2/example-1.js'
+Checksum updated from 12345 to 60367141
 
 <group 2 file(s) would have been fixed.
 To fix, run: >
@@ -4343,7 +4351,11 @@ exports[`Integration Tests (see __examples__ folder) Example migrate_all should 
     "**/migrate_all/**"
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
-  "cacheMode": "read"
+  "cacheMode": "read",
+  "migration": {
+    "mode": "all",
+    "mappings": {}
+  }
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4403,7 +4415,7 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mode": "missing",
+    "mode": "all",
     "mappings": {
       "__examples__/migrate_missing_target/": "https://example.com/1/",
       "__examples__/migrate_all/": "https://example.com/2/",
@@ -4412,12 +4424,10 @@ Verbose  Combined options with defaults: {
   }
 }
 Info     Loading cache from ROOT_DIR/.integrationtests/migrate_all.json
-Mismatch __examples__/migrate_all/example-1.js:3
-Looks like you changed the target content for sync-tag 'migrate_all' in '__examples__/migrate_all/example-2.js:3'
-Make sure you've made corresponding changes in the source file, if necessary (12345 != 770446101)
-Mismatch __examples__/migrate_all/example-2.js:3
-Looks like you changed the target content for sync-tag 'migrate_all' in '__examples__/migrate_all/example-1.js:3'
-Make sure you've made corresponding changes in the source file, if necessary (12345 != 770446101)
+Migrate  __examples__/migrate_all/example-1.js:3
+Recommended migration to remote target 'https://example.com/2/example-2.js' and update checksum to 60104996.
+Migrate  __examples__/migrate_all/example-2.js:3
+Recommended migration to remote target 'https://example.com/2/example-1.js' and update checksum to 60367141.
 
 <group 🛠  Desynchronized blocks detected. Check them and update as required before resynchronizing: >
 
@@ -4432,7 +4442,11 @@ exports[`Integration Tests (see __examples__ folder) Example migrate_all should 
   ],
   "json": true,
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
-  "cacheMode": "read"
+  "cacheMode": "read",
+  "migration": {
+    "mode": "all",
+    "mappings": {}
+  }
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4492,7 +4506,7 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mode": "missing",
+    "mode": "all",
     "mappings": {
       "__examples__/migrate_missing_target/": "https://example.com/1/",
       "__examples__/migrate_all/": "https://example.com/2/",
@@ -4508,34 +4522,34 @@ Info     Loading cache from ROOT_DIR/.integrationtests/migrate_all.json
         "__examples__/migrate_all/example-1.js": [
             {
                 "markerID": "migrate_all",
-                "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'migrate_all' in '__examples__/migrate_all/example-2.js:3'. Make sure you've made corresponding changes in the source file, if necessary (12345 != 770446101)",
+                "reason": "Recommended migration to remote target 'https://example.com/2/example-2.js' and update checksum to 60104996.",
+                "code": "pending-migration",
                 "location": {
                     "line": 3
                 },
                 "fix": {
                     "type": "replace",
                     "line": 3,
-                    "text": "// sync-start:migrate_all 770446101 __examples__/migrate_all/example-2.js",
+                    "text": "// sync-start:migrate_all 60104996 https://example.com/2/example-2.js",
                     "declaration": "// sync-start:migrate_all 12345 __examples__/migrate_all/example-2.js",
-                    "description": "Updated checksum for sync-tag 'migrate_all' referencing '__examples__/migrate_all/example-2.js:3' from 12345 to 770446101."
+                    "description": "Migrated sync-tag 'migrate_all'. Target changed from '__examples__/migrate_all/example-2.js' to 'https://example.com/2/example-2.js'. Checksum updated from 12345 to 60104996"
                 }
             }
         ],
         "__examples__/migrate_all/example-2.js": [
             {
                 "markerID": "migrate_all",
-                "code": "mismatched-checksum",
-                "reason": "Looks like you changed the target content for sync-tag 'migrate_all' in '__examples__/migrate_all/example-1.js:3'. Make sure you've made corresponding changes in the source file, if necessary (12345 != 770446101)",
+                "reason": "Recommended migration to remote target 'https://example.com/2/example-1.js' and update checksum to 60367141.",
+                "code": "pending-migration",
                 "location": {
                     "line": 3
                 },
                 "fix": {
                     "type": "replace",
                     "line": 3,
-                    "text": "// sync-start:migrate_all 770446101 __examples__/migrate_all/example-1.js",
+                    "text": "// sync-start:migrate_all 60367141 https://example.com/2/example-1.js",
                     "declaration": "// sync-start:migrate_all 12345 __examples__/migrate_all/example-1.js",
-                    "description": "Updated checksum for sync-tag 'migrate_all' referencing '__examples__/migrate_all/example-1.js:3' from 12345 to 770446101."
+                    "description": "Migrated sync-tag 'migrate_all'. Target changed from '__examples__/migrate_all/example-1.js' to 'https://example.com/2/example-1.js'. Checksum updated from 12345 to 60367141"
                 }
             }
         ]
@@ -4549,7 +4563,11 @@ exports[`Integration Tests (see __examples__ folder) Example migrate_all should 
     "**/migrate_all/**"
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
-  "cacheMode": "write"
+  "cacheMode": "write",
+  "migration": {
+    "mode": "all",
+    "mappings": {}
+  }
 }
 Verbose  Looking for configuration file based on root marker...
 Verbose  Checking ROOT_DIR/.checksyncrc...
@@ -4609,7 +4627,7 @@ Verbose  Combined options with defaults: {
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
-    "mode": "missing",
+    "mode": "all",
     "mappings": {
       "__examples__/migrate_missing_target/": "https://example.com/1/",
       "__examples__/migrate_all/": "https://example.com/2/",

--- a/src/__tests__/determine-migration.test.ts
+++ b/src/__tests__/determine-migration.test.ts
@@ -26,10 +26,10 @@ describe("determineMigration", () => {
         // Arrange
         const options: Options = {
             migration: {
-                mappings: new Map([
-                    ["anothertest/1", "http://example.com/1/"],
-                    ["test/1/", "https://example.com/2/"],
-                ]),
+                mappings: {
+                    "anothertest/1": "http://example.com/1/",
+                    "test/1/": "https://example.com/2/",
+                },
             },
         } as any;
         const sourceRef: Target = {target: "test/1/file.ts"} as any;
@@ -45,11 +45,12 @@ describe("determineMigration", () => {
         // Arrange
         const options: Options = {
             migration: {
-                mappings: new Map([
-                    ["a/", "http://example.com/shortest/"],
-                    ["a/b/c/", "https://example.com/longest/"],
-                    ["a/b/", "https://example.com/middle/"],
-                ]),
+                mode: "missing",
+                mappings: {
+                    "a/": "http://example.com/shortest/",
+                    "a/b/c/": "https://example.com/longest/",
+                    "a/b/": "https://example.com/middle/",
+                },
             },
         } as any;
         const sourceRef: Target = {target: "a/b/c/file.ts"} as any;

--- a/src/__tests__/get-launch-string.test.ts
+++ b/src/__tests__/get-launch-string.test.ts
@@ -73,7 +73,7 @@ describe("#getLaunchString", () => {
             expect(result).toBe("pnpm checksync");
         });
 
-        it("and npm_execpath is not yarn, should return `npx checksync`", () => {
+        it("and npm_execpath is not yarn nor pnpm, should return `npx checksync`", () => {
             // Arrange
             jest.spyOn(path, "join").mockReturnValueOnce(".bin/checksync");
             jest.spyOn(CwdRelativePath, "default").mockReturnValueOnce(

--- a/src/__tests__/integration-test-support.test.ts
+++ b/src/__tests__/integration-test-support.test.ts
@@ -186,6 +186,26 @@ describe("integration-test-support", () => {
                 expect.any(StringLogger),
             );
         });
+
+        it("should run checkSync with migration mode all when example is `migrate_all` example", async () => {
+            // Arrange
+            const checkSyncSpy = jest
+                .spyOn(Checksync, "default")
+                .mockResolvedValueOnce(ExitCode.SUCCESS);
+
+            // Act
+            await runChecksync("migrate_all", Scenario.CheckOnly);
+
+            // Assert
+            expect(checkSyncSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    migration: expect.objectContaining({
+                        mode: "all",
+                    }),
+                }),
+                expect.any(StringLogger),
+            );
+        });
     });
 
     describe("writeLog", () => {

--- a/src/__tests__/load-configuration-file.test.ts
+++ b/src/__tests__/load-configuration-file.test.ts
@@ -306,7 +306,7 @@ describe("#loadConfigurationFile", () => {
             "loadMigrationConfig",
         ).mockReturnValueOnce({
             mode: "all",
-            mappings: new Map([["a", "https://example.com"]]),
+            mappings: {a: "https://example.com"},
         });
 
         // Act
@@ -316,7 +316,7 @@ describe("#loadConfigurationFile", () => {
         expect(result).toEqual({
             migration: {
                 mode: "all",
-                mappings: new Map([["a", "https://example.com"]]),
+                mappings: {a: "https://example.com"},
             },
         });
     });

--- a/src/__tests__/load-migration-config.test.ts
+++ b/src/__tests__/load-migration-config.test.ts
@@ -90,10 +90,10 @@ describe("loadMigrationConfig", () => {
         // Assert
         expect(result).toEqual({
             mode: "all",
-            mappings: new Map([
-                ["a", "b"],
-                ["c", "d"],
-            ]),
+            mappings: {
+                a: "b",
+                c: "d",
+            },
         });
     });
 });

--- a/src/__tests__/options-from-args.test.ts
+++ b/src/__tests__/options-from-args.test.ts
@@ -370,4 +370,33 @@ describe("#optionsFromArgs", () => {
         // Assert
         expect(result.cachePath).not.toBeDefined();
     });
+
+    it("should not add migration if args.migrate is not provided", () => {
+        // Arrange
+        const args: any = {
+            migrate: null,
+        };
+
+        // Act
+        const result = optionsFromArgs(args);
+
+        // Assert
+        expect(result.migration).not.toBeDefined();
+    });
+
+    it("should add migration if args.migrate is provided", () => {
+        // Arrange
+        const args: any = {
+            migrate: "SHENANIGANS",
+        };
+
+        // Act
+        const result = optionsFromArgs(args);
+
+        // Assert
+        expect(result.migration).toEqual({
+            mode: "SHENANIGANS",
+            mappings: {},
+        });
+    });
 });

--- a/src/determine-migration.ts
+++ b/src/determine-migration.ts
@@ -10,36 +10,34 @@ export const determineMigration = (
     sourceRef: Target,
 ): string | undefined => {
     // Does this error relate to a migrateable target?
-    const {migratedTarget} = (
-        options.migration?.mappings ?? new Map<string, string>()
-    )
-        .entries()
-        .reduce(
-            (migration, [from, to]) => {
-                const currentTarget = normalizeSeparators(
-                    rootRelativePath(sourceRef.target, options.rootMarker),
-                );
-                // We want the best match, which, since we only check
-                // that the target starts with the match, is determined to be
-                // the longest match.
-                if (
-                    currentTarget.startsWith(from) &&
-                    from.length > migration.matchLength
-                ) {
-                    return {
-                        matchLength: from.length,
-                        // Return the target with the `from` portion
-                        // replaced by `to`.
-                        migratedTarget: currentTarget.replace(from, to),
-                    };
-                }
-                return migration;
-            },
-            {
-                matchLength: 0,
-                migratedTarget: undefined as string | undefined,
-            },
-        );
+    const {migratedTarget} = Object.entries(
+        options.migration?.mappings ?? {},
+    ).reduce(
+        (migration, [from, to]) => {
+            const currentTarget = normalizeSeparators(
+                rootRelativePath(sourceRef.target, options.rootMarker),
+            );
+            // We want the best match, which, since we only check
+            // that the target starts with the match, is determined to be
+            // the longest match.
+            if (
+                currentTarget.startsWith(from) &&
+                from.length > migration.matchLength
+            ) {
+                return {
+                    matchLength: from.length,
+                    // Return the target with the `from` portion
+                    // replaced by `to`.
+                    migratedTarget: currentTarget.replace(from, to),
+                };
+            }
+            return migration;
+        },
+        {
+            matchLength: 0,
+            migratedTarget: undefined as string | undefined,
+        },
+    );
 
     return migratedTarget;
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -243,6 +243,45 @@ export const noReturnTag = (
 });
 
 /**
+ * Create an error indicating a pending migration for a matching tag.
+ *
+ * @param markerID The ID of the marker that is affected.
+ * @param declaration The original declaration of the marker exhibiting the
+ * mismatch.
+ * @param line The line number where the marker is located.
+ * @param oldTargetRootRelativeOrRemote The old target path.
+ * @param migratedTarget The target to which the marker should be migrated.
+ * @param incorrectChecksum The incorrect checksum.
+ * @param correctChecksum The correct checksum.
+ * @param fixedTag The fixed tag that should replace the mismatched one.
+ * @returns The error details.
+ */
+export const pendingMigrationForMatchingTag = (
+    markerID: string,
+    declaration: string,
+    line: number,
+    oldTargetRootRelativeOrRemote: string,
+    migratedTarget: string,
+    incorrectChecksum: string,
+    correctChecksum: string,
+    fixedTag: string,
+): ErrorDetails => {
+    return {
+        markerID,
+        reason: `Recommended migration to remote target '${migratedTarget}' and update checksum to ${correctChecksum}.`,
+        code: ErrorCode.pendingMigration,
+        location: {line},
+        fix: {
+            type: "replace",
+            line,
+            text: fixedTag,
+            declaration,
+            description: `Migrated sync-tag '${markerID}'. Target changed from '${oldTargetRootRelativeOrRemote}' to '${migratedTarget}'. Checksum updated from ${incorrectChecksum.toLowerCase()} to ${correctChecksum}`,
+        },
+    };
+};
+
+/**
  * Create an error indicating a pending migration for missing local return tag.
  *
  * @param options The options for the current run.

--- a/src/integration-test-support.ts
+++ b/src/integration-test-support.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-unassigned-import
-import "./polyfills";
 import path from "path";
 import fs from "fs";
 import ancesdir from "ancesdir";
@@ -49,6 +47,9 @@ export const runChecksync = async (
     example: string,
     scenario?: Scenario,
 ): Promise<string> => {
+    // Migrate all example is a special case where we want to run it with an
+    // additional option.
+    const migrate = example.includes("migrate-all") ? "all" : undefined;
     const stringLogger = new StringLogger(true);
 
     // This has to be an actual glob, or it won't work.
@@ -57,11 +58,11 @@ export const runChecksync = async (
     // Depending on the scenario, let's set up the args object.
     const scenarioArgs =
         scenario == null || scenario === Scenario.CheckOnly
-            ? {}
+            ? {migrate}
             : scenario === Scenario.JsonCheckOnly
-              ? {json: true}
+              ? {json: true, migrate}
               : scenario === Scenario.Autofix
-                ? {updateTags: true, dryRun: true}
+                ? {updateTags: true, dryRun: true, migrate}
                 : null;
 
     if (scenarioArgs == null) {

--- a/src/integration-test-support.ts
+++ b/src/integration-test-support.ts
@@ -49,7 +49,7 @@ export const runChecksync = async (
 ): Promise<string> => {
     // Migrate all example is a special case where we want to run it with an
     // additional option.
-    const migrate = example.includes("migrate-all") ? "all" : undefined;
+    const migrate = example.includes("migrate_all") ? "all" : undefined;
     const stringLogger = new StringLogger(true);
 
     // This has to be an actual glob, or it won't work.

--- a/src/load-migration-config.ts
+++ b/src/load-migration-config.ts
@@ -69,7 +69,8 @@ export const loadMigrationConfig = (
     }
 
     return {
-        mode: migrationConfig.mode,
-        mappings,
+        // Make sure to provide our default value if one wasn't given.
+        mode: migrationConfig.mode ?? "missing",
+        mappings: Object.fromEntries(mappings),
     };
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-unassigned-import
-import "./polyfills";
 export {run as runCli} from "./cli";
 export {default as checkSync} from "./check-sync";
 export {default as loadConfigurationFile} from "./load-configuration-file";

--- a/src/options-from-args.ts
+++ b/src/options-from-args.ts
@@ -71,5 +71,12 @@ export const optionsFromArgs = (args: Arguments<any>): Partial<Options> => {
         options.cacheMode = "read";
     }
 
+    if (args.migrate != null) {
+        options.migration = {
+            mode: args.migrate,
+            mappings: {},
+        };
+    }
+
     return options;
 };

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -28,6 +28,7 @@ export const parseArgs = (log: ILog) =>
             "config",
             "outputCache",
             "fromCache",
+            "migrate",
         ])
         .option("outputCache", {
             type: "string",
@@ -43,7 +44,15 @@ export const parseArgs = (log: ILog) =>
                 "ignoreFiles",
                 "config",
                 "outputCache",
+                "help",
+                "version",
             ],
+        })
+        .option("migrate", {
+            type: "string",
+            choices: ["all", "missing"],
+            description: "Migrate all or only unreturned tags",
+            conflicts: ["help", "version"],
         })
         .alias("comments", ["c"])
         .alias("dryRun", ["n", "dry-run"])

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,2 +1,0 @@
-/* eslint-disable import/no-unassigned-import */
-import "es-iterator-helpers/auto";

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,7 +207,7 @@ export type normalizeTargetFn = (
 
 export type MigrationOptions = {
     mode: "all" | "missing";
-    mappings: ReadonlyMap<string, string>;
+    mappings: Record<string, string>;
 };
 
 export type Options = {

--- a/tsconfig-shared.json
+++ b/tsconfig-shared.json
@@ -4,8 +4,7 @@
         /* Language and Environment */
         "target": "es2022",
         "lib": [
-            "es2023",
-            "esnext.iterator"
+            "es2023"
         ],
         /* Modules */
         // Required for dynamic imports even though we aren't using


### PR DESCRIPTION
## Summary:
This makes the following changes:
- Fixes log output of options by removing use of `Map` instance
- Removes the iterator-helpers polyfill (the replacement of the `Map` instance with a POJO means we use `Object.entries` and the Array-based helpers)
- Adds a new argument, `migrate` to override the migration mode of the configuration file
- Properly defaults the migration mode (previously, it wasn't getting defaulted correctly)
- Adds an integration test for the new migrate=all mode

This completes the new sync-tag format work, and closes #2036 and #2009. We can release v8 after this lands.

Issue: FEI-6294, closes #2036 and #2009

## Test plan:
`pnpm test`

- Run `./bin/checksync.dev.ts --migrate=all __examples__/migrate_all`