### PR TITLE
Update ancesdir and add nicer error output

### DIFF
--- a/.changeset/icy-geese-laugh.md
+++ b/.changeset/icy-geese-laugh.md
@@ -1,0 +1,5 @@
+---
+"checksync": minor
+---
+
+Fix bug with output sink and improve error messaging when root marker cannot be found

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -161,5 +161,5 @@ jobs:
       env:
         # We only want to upload bundle analysis for a PR once,
         # so we only provide a token for the ubuntu-latest job.
-        CODECOV_TOKEN: ${{ matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN || '' }}
+        CODECOV_TOKEN: ${{ matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN }}
       run: pnpm build

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -161,5 +161,5 @@ jobs:
       env:
         # We only want to upload bundle analysis for a PR once,
         # so we only provide a token for the ubuntu-latest job.
-        CODECOV_TOKEN: ${{ matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN || '' }}
       run: pnpm build

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "@typescript-eslint/eslint-plugin": "^8.29.0",
         "@typescript-eslint/parser": "^8.29.0",
         "adler-32": "^1.3.1",
-        "ancesdir": "^6.0.0",
+        "ancesdir": "^7.0.0",
         "babel-jest": "^29.7.0",
         "chalk": "^4.0.0",
         "eslint": "^9.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1
       ancesdir:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^7.0.0
+        version: 7.0.0
       babel-jest:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.26.10)
@@ -1883,9 +1883,9 @@ packages:
     resolution: {integrity: sha512-s61cXyQspPAwsFvf2UJYAZpLOqTKS12fjUxOebi4ymUCLuSn0f0trGBe+a3bFEH0Yw4zgQDxXkYFsvc6YbQpkw==}
     engines: {node: '>=16', npm: please-use-yarn, yarn: '>=1.18.0 <2'}
 
-  ancesdir@6.0.0:
-    resolution: {integrity: sha512-WTgCOi7D15lDHIijVh/NZnC4nRu3Ay2NZ1SkfsRKexj6Cd20zsFDW1kYfHMa42kJvHMO3103aVg7mMFd58uiWA==}
-    engines: {node: '>=20', npm: please-use-yarn, yarn: '>=1.18.0 <2'}
+  ancesdir@7.0.0:
+    resolution: {integrity: sha512-ccfX9oRhDJTUwE2ryOTl7I7IHcWWhtEODH2EtvkZOPU2/sFqg4Wchy6nyj2ZiVFuWNvIE5kNo8hKTrlZ+bq97A==}
+    engines: {node: '>=20', npm: please-use-pnpm, yarn: please-use-pnpm}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -6502,7 +6502,7 @@ snapshots:
 
   ancesdir@5.0.1: {}
 
-  ancesdir@6.0.0: {}
+  ancesdir@7.0.0: {}
 
   ansi-align@3.0.1:
     dependencies:

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -40,16 +40,16 @@ export default {
                 },
             ],
         }),
-        process.env.CODECOV_TOKEN == null
-            ? // This plugin outputs size info to the console when local.
-              filesize()
-            : // This plugin provides bundle analysis from codecov, but does
+        process.env.CODECOV_TOKEN
+            ? // This plugin provides bundle analysis from codecov, but does
               // not work locally without additional config, and it does not
               // output size info to the console.
               codecovRollupPlugin({
-                  enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+                  enableBundleAnalysis: true, // true when CODECOV_TOKEN set
                   bundleName: "checksync",
                   uploadToken: process.env.CODECOV_TOKEN,
-              }),
+              })
+            : // This plugin outputs size info to the console when local.
+              filesize(),
     ],
 };

--- a/src/__tests__/__snapshots__/format.test.ts.snap
+++ b/src/__tests__/__snapshots__/format.test.ts.snap
@@ -6,6 +6,8 @@ exports[`Format #cwdFilePath should render with chalk colors 1`] = `"[90mTest[
 
 exports[`Format #error should prefix with _ERROR__ 1`] = `"Error    Test"`;
 
+exports[`Format #error should remove 'Error: ' prefix from message if there is one 1`] = `"Error    Test"`;
+
 exports[`Format #error should render with chalk colors 1`] = `"[31mError   [39m Test"`;
 
 exports[`Format #fix should prefix with _FIX_ 1`] = `"Fix      Test"`;
@@ -17,6 +19,10 @@ exports[`Format #heading should render with chalk colors 1`] = `"[1m[32mTest[
 exports[`Format #info should prefix with _INFO__ 1`] = `"Info     Test"`;
 
 exports[`Format #info should render with chalk colors 1`] = `"[34mInfo    [39m Test"`;
+
+exports[`Format #migrate should prefix with _MIGRATE__ 1`] = `"Migrate  Test"`;
+
+exports[`Format #migrate should render with chalk colors 1`] = `"[1m[93mMigrate [39m[22m Test"`;
 
 exports[`Format #mismatch should prefix with _MISMATCH__ 1`] = `"Mismatch Test"`;
 

--- a/src/__tests__/ancesdir-or-currentdir.test.ts
+++ b/src/__tests__/ancesdir-or-currentdir.test.ts
@@ -21,4 +21,19 @@ describe("ancesdirOrCurrentDir", () => {
             "MARKER",
         );
     });
+
+    it("should throw a useful error if ancesdir fails", () => {
+        // Arrange
+        jest.spyOn(Ancesdir, "default").mockImplementation(() => {
+            throw new Error("Fake error");
+        });
+
+        // Act
+        const underTest = () => ancesdirOrCurrentDir("FILE", "MARKER");
+
+        // Assert
+        expect(underTest).toThrowErrorMatchingInlineSnapshot(
+            `"Unable to locate directory containing marker file "MARKER" from starting location "FILE""`,
+        );
+    });
 });

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -263,9 +263,8 @@ describe("#run", () => {
 
     it("should log error on rejection of checkSync method", async () => {
         // Arrange
-        jest.spyOn(CheckSync, "default").mockRejectedValue(
-            new Error("Oh no, booms!"),
-        );
+        const error = new Error("Oh no, booms!");
+        jest.spyOn(CheckSync, "default").mockRejectedValue(error);
         jest.spyOn(DetermineOptions, "default").mockResolvedValue(
             defaultOptions,
         );
@@ -278,9 +277,7 @@ describe("#run", () => {
         await run(__filename);
 
         // Assert
-        expect(logSpy).toHaveBeenCalledWith(
-            "Unexpected error: Error: Oh no, booms!",
-        );
+        expect(logSpy).toHaveBeenCalledWith(error.stack);
     });
 
     it("should exit with CATASTROPHIC code on rejection of checkSync method", async () => {

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -71,6 +71,16 @@ describe("Format", () => {
             // Assert
             expect(result).toMatchSnapshot();
         });
+
+        it("should remove 'Error: ' prefix from message if there is one", () => {
+            // Arrange
+
+            // Act
+            const result = Format.error("Error: Test");
+
+            // Assert
+            expect(result).toMatchSnapshot();
+        });
     });
 
     describe("#warn", () => {
@@ -113,6 +123,29 @@ describe("Format", () => {
 
             // Act
             const result = Format.mismatch("Test");
+
+            // Assert
+            expect(result).toMatchSnapshot();
+        });
+    });
+
+    describe("#migrate", () => {
+        it("should prefix with _MIGRATE__", () => {
+            // Arrange
+
+            // Act
+            const result = Format.migrate("Test");
+
+            // Assert
+            expect(result).toMatchSnapshot();
+        });
+
+        it("should render with chalk colors", () => {
+            // Arrange
+            chalk.level = 1;
+
+            // Act
+            const result = Format.migrate("Test");
 
             // Assert
             expect(result).toMatchSnapshot();

--- a/src/ancesdir-or-currentdir.ts
+++ b/src/ancesdir-or-currentdir.ts
@@ -12,8 +12,15 @@ export const ancesdirOrCurrentDir = (
     startPath: string,
     marker?: string | null,
 ): string => {
-    // When this method is called, we want ancesdir to start the search inside
-    // the same folder as the given file, so we add a fake child onto the file,
-    // which ancesdir will strip.
-    return ancesdir(path.join(startPath, "__fake__"), marker ?? undefined);
+    try {
+        // When this method is called, we want ancesdir to start the search inside
+        // the same folder as the given file, so we add a fake child onto the file,
+        // which ancesdir will strip.
+        return ancesdir(path.join(startPath, "__fake__"), marker ?? undefined);
+    } catch (e) {
+        throw new Error(
+            `Unable to locate directory containing marker file "${marker}" from starting location "${startPath}"`,
+            {cause: e},
+        );
+    }
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,7 +94,7 @@ export const run = async (launchFilePath: string): Promise<void> => {
                 exit(log, exitCode);
             },
             (e) => {
-                log.error(`Unexpected error: ${e}`);
+                log.error(e.stack);
                 exit(log, ExitCode.CATASTROPHIC);
             },
         );

--- a/src/format.ts
+++ b/src/format.ts
@@ -22,8 +22,12 @@ const asLabel = (label: Label): string =>
 const Format = {
     verbose: (text: string): string =>
         `${chalk.grey(asLabel(Label.Verbose))} ${chalk.dim(text)}`,
-    error: (text: string): string =>
-        `${chalk.red(asLabel(Label.Error))} ${text}`,
+    error: (text: string): string => {
+        if (text.startsWith("Error: ")) {
+            text = text.substring("Error: ".length);
+        }
+        return `${chalk.red(asLabel(Label.Error))} ${text}`;
+    },
     info: (text: string): string =>
         `${chalk.blue(asLabel(Label.Info))} ${text}`,
     warn: (text: string): string =>

--- a/src/output-sink.ts
+++ b/src/output-sink.ts
@@ -29,19 +29,24 @@ export default class OutputSink {
         this._options = options;
     }
 
+    _getKeyForFile(file: string): string {
+        try {
+            return rootRelativePath(file, this._options.rootMarker);
+        } catch (e) {
+            return file;
+        }
+    }
+
     _getErrorsForFile(file: string): Array<ErrorDetails> {
-        return this._errorsByFile[
-            rootRelativePath(file, this._options.rootMarker)
-        ];
+        return this._errorsByFile[this._getKeyForFile(file)];
     }
 
     _initErrorsForFile(file: string): void {
-        this._errorsByFile[rootRelativePath(file, this._options.rootMarker)] =
-            [];
+        this._errorsByFile[this._getKeyForFile(file)] = [];
     }
 
     _cleanUpErrorlessFile(file: string): boolean {
-        const relativePath = rootRelativePath(file, this._options.rootMarker);
+        const relativePath = this._getKeyForFile(file);
         if (this._errorsByFile[relativePath].length === 0) {
             delete this._errorsByFile[relativePath];
             return true;


### PR DESCRIPTION
## Summary:
This updates to the latest ancesdir, and also adds some clearer error output if it fails. In addition, we now include the stack for unexpected errors, and the output sink is properly handling path errors so that we get a more consistent output.

So, now for the common case like the one that led to this, folks will see output like:

```
Error    __examples__/content_after_start/a.js
Could not parse /Users/jeffyates/git/checksync/__examples__/content_after_start/a.js: Unable to locate directory containing marker file "madeupmarkerfile" from starting location "/Users/jeffyates/git/checksync/__examples__/content_after_start/a.js"

Error    __examples__/content_after_start/b.py
Could not parse /Users/jeffyates/git/checksync/__examples__/content_after_start/b.py: Unable to locate directory containing marker file "madeupmarkerfile" from starting location "/Users/jeffyates/git/checksync/__examples__/content_after_start/b.py"
```

And for unexpected errors, they would see something like (though this specific error cannot occur anymore since the above output happens instead):
```
Error    Unable to locate directory containing marker file "madeupmarkerfile" from starting location "/Users/jeffyates/git/checksync/__examples__/checksums_need_updating/README.md"
    at ancesdirOrCurrentDir (/Users/jeffyates/git/checksync/src/ancesdir-or-currentdir.ts:21:15)
    at _default (/Users/jeffyates/git/checksync/src/root-relative-path.ts:8:42)
    at OutputSink._initErrorsForFile (/Users/jeffyates/git/checksync/src/output-sink.ts:44:44)
    at OutputSink.startFile (/Users/jeffyates/git/checksync/src/output-sink.ts:67:14)
    at processCache (/Users/jeffyates/git/checksync/src/process-cache.ts:18:20)
    at checkSync (/Users/jeffyates/git/checksync/src/check-sync.ts:40:28)
```

Issue: Closes #2106

## Test plan:
`pnpm test`
I also ran `./bin/checksync.dev.js --verbose --rootMarker madeupmarkerfile __examples__` and verified that the output was correct.