### PR TITLE
Include dot paths

### DIFF
--- a/.changeset/warm-actors-divide.md
+++ b/.changeset/warm-actors-divide.md
@@ -1,0 +1,5 @@
+---
+"checksync": major
+---
+
+Include dot paths when parsing include globs. This is a breaking change as this is turned on by default. To turn off, use the `--includeDotPaths=false` or explicitly set `includeDotPaths` in your config file.

--- a/__examples__/dot_paths_with_correct_checksum/.checkme1
+++ b/__examples__/dot_paths_with_correct_checksum/.checkme1
@@ -1,0 +1,3 @@
+// sync-start:update_me 1473833596 __examples__/dot_paths_with_correct_checksum/.checkme2
+Perhaps an ignore file. Who knows.
+// sync-end:update_me

--- a/__examples__/dot_paths_with_correct_checksum/.checkme2
+++ b/__examples__/dot_paths_with_correct_checksum/.checkme2
@@ -1,0 +1,3 @@
+// sync-start:update_me 455799753 __examples__/dot_paths_with_correct_checksum/.checkme1
+Perhaps another ignore file or some config file. Who knows.
+// sync-end:update_me

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -65,6 +65,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -163,6 +164,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -258,6 +260,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -407,6 +410,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -504,6 +508,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -605,6 +610,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -708,6 +714,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -874,6 +881,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -968,6 +976,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1047,6 +1056,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1126,6 +1136,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1208,6 +1219,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1302,6 +1314,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1388,6 +1401,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1474,6 +1488,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1576,6 +1591,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1602,6 +1618,343 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/directory_target/example.js"
 ]
 Info     Cache written to ROOT_DIR/.integrationtests/directory_target.json"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example dot_paths_with_correct_checksum should report example dot_paths_with_correct_checksum to match snapshot for scenario autofix 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/dot_paths_with_correct_checksum/**"
+  ],
+  "autoFix": true,
+  "dryRun": true,
+  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
+  "cacheMode": "read"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false,
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Verbose  Combined options with defaults: {
+  "autoFix": true,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": true,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/dot_paths_with_correct_checksum/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
+  "cacheMode": "read",
+  "includeDotPaths": true,
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Info     DRY-RUN: Files will not be modified
+Info     Loading cache from ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json
+🎉  Everything is in sync!"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example dot_paths_with_correct_checksum should report example dot_paths_with_correct_checksum to match snapshot for scenario check-only 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/dot_paths_with_correct_checksum/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
+  "cacheMode": "read"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false,
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/dot_paths_with_correct_checksum/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
+  "cacheMode": "read",
+  "includeDotPaths": true,
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Info     Loading cache from ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json
+🎉  Everything is in sync!"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example dot_paths_with_correct_checksum should report example dot_paths_with_correct_checksum to match snapshot for scenario json-check-only 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/dot_paths_with_correct_checksum/**"
+  ],
+  "json": true,
+  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
+  "cacheMode": "read"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false,
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": true,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/dot_paths_with_correct_checksum/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
+  "cacheMode": "read",
+  "includeDotPaths": true,
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Info     Loading cache from ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json
+{
+    "version": "0.0.0",
+    "launchString": "checksync -u ",
+    "files": {}
+}"
+`;
+
+exports[`Integration Tests (see __examples__ folder) Example dot_paths_with_correct_checksum should report example dot_paths_with_correct_checksum to match snapshot for scenario undefined 1`] = `
+"Verbose  Options from arguments: {
+  "includeGlobs": [
+    "**/dot_paths_with_correct_checksum/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
+  "cacheMode": "write"
+}
+Verbose  Looking for configuration file based on root marker...
+Verbose  Checking ROOT_DIR/.checksyncrc...
+Verbose  Checking ROOT_DIR/.checksyncrc.json...
+Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
+Verbose  Changing working directory to ROOT_DIR
+Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
+Verbose  Validating configuration
+Verbose  Configuration is valid
+Verbose  Options from config: {
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "autoFix": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "dryRun": false,
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "json": false,
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Verbose  Combined options with defaults: {
+  "autoFix": false,
+  "json": false,
+  "allowEmptyTags": false,
+  "comments": [
+    "//",
+    "#",
+    "{/*"
+  ],
+  "excludeGlobs": [
+    "**/excluded/**"
+  ],
+  "dryRun": false,
+  "ignoreFiles": [
+    "**/ignore-file.txt"
+  ],
+  "includeGlobs": [
+    "**/dot_paths_with_correct_checksum/**"
+  ],
+  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
+  "cacheMode": "write",
+  "includeDotPaths": true,
+  "$schema": "./src/checksync.schema.json",
+  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
+  "migration": {
+    "mode": "missing",
+    "mappings": {
+      "__examples__/migrate_missing_target/": "https://example.com/1/",
+      "__examples__/migrate_all/": "https://example.com/2/",
+      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
+    }
+  }
+}
+Verbose  Ignore files: [
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
+    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
+]
+Verbose  Include globs: [
+    "**/dot_paths_with_correct_checksum/**"
+]
+Verbose  Exclude globs: [
+    "**/excluded/**"
+]
+Verbose  Discovered paths: [
+    "ROOT_DIR/__examples__/dot_paths_with_correct_checksum/.checkme1",
+    "ROOT_DIR/__examples__/dot_paths_with_correct_checksum/.checkme2"
+]
+Info     Cache written to ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example duplicate-target should report example duplicate-target to match snapshot for scenario autofix 1`] = `
@@ -1669,6 +2022,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1763,6 +2117,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1857,6 +2212,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2003,6 +2359,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2096,6 +2453,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2180,6 +2538,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2264,6 +2623,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2358,6 +2718,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2451,6 +2812,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2535,6 +2897,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2619,6 +2982,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2713,6 +3077,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2805,6 +3170,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2884,6 +3250,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2963,6 +3330,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3041,6 +3409,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3131,6 +3500,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3215,6 +3585,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3299,6 +3670,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3393,6 +3765,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3492,6 +3865,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3583,6 +3957,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3674,6 +4049,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3794,6 +4170,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3887,6 +4264,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3983,6 +4361,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4079,6 +4458,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4217,6 +4597,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4315,6 +4696,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4415,6 +4797,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4506,6 +4889,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4627,6 +5011,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4720,6 +5105,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_missing_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4814,6 +5200,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_missing_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4903,6 +5290,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_missing_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5018,6 +5406,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_missing_target.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5110,6 +5499,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5196,6 +5586,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5282,6 +5673,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5384,6 +5776,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5476,6 +5869,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5560,6 +5954,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5644,6 +6039,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5738,6 +6134,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5831,6 +6228,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5923,6 +6321,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6012,6 +6411,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6129,6 +6529,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6222,6 +6623,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6311,6 +6713,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6403,6 +6806,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6512,6 +6916,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6604,6 +7009,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6692,6 +7098,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6778,6 +7185,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6878,6 +7286,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6970,6 +7379,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7049,6 +7459,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7128,6 +7539,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7210,6 +7622,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7303,6 +7716,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7390,6 +7804,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7477,6 +7892,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7581,6 +7997,7 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "write",
+  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {

--- a/src/__tests__/check-sync.test.ts
+++ b/src/__tests__/check-sync.test.ts
@@ -39,6 +39,7 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "ignore",
+                    includeDotPaths: false,
                 },
                 NullLogger,
             );
@@ -55,31 +56,25 @@ describe("#checkSync", () => {
             const getFilesSpy = jest
                 .spyOn(GetFiles, "default")
                 .mockResolvedValue([]);
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: true,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "ignore",
+                includeDotPaths: false,
+            };
 
             // Act
-            await checkSync(
-                {
-                    includeGlobs: ["glob1", "glob2"],
-                    excludeGlobs: [],
-                    ignoreFiles: [],
-                    dryRun: false,
-                    autoFix: true,
-                    comments: ["//"],
-                    json: false,
-                    allowEmptyTags: false,
-                    cachePath: "",
-                    cacheMode: "ignore",
-                },
-                NullLogger,
-            );
+            await checkSync(options, NullLogger);
 
             // Assert
-            expect(getFilesSpy).toHaveBeenCalledWith(
-                ["glob1", "glob2"],
-                [],
-                [],
-                NullLogger,
-            );
+            expect(getFilesSpy).toHaveBeenCalledWith(options, NullLogger);
         });
 
         it("should log error when there are no matching files", async () => {
@@ -98,6 +93,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
+                includeDotPaths: false,
             };
 
             // Act
@@ -122,6 +118,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
+                includeDotPaths: false,
             };
 
             // Act
@@ -149,6 +146,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
+                includeDotPaths: false,
             };
 
             // Act
@@ -177,6 +175,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
+                includeDotPaths: false,
             };
 
             // Act
@@ -210,6 +209,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
+                includeDotPaths: false,
             };
 
             // Act
@@ -248,6 +248,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
+                includeDotPaths: false,
             };
 
             // Act
@@ -289,6 +290,7 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "ignore",
+                    includeDotPaths: false,
                 },
                 NullLogger,
             );
@@ -318,6 +320,7 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "read",
+                    includeDotPaths: false,
                 },
                 NullLogger,
             );
@@ -347,6 +350,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "read",
+                includeDotPaths: false,
             };
 
             // Act
@@ -374,6 +378,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "read",
+                includeDotPaths: false,
             };
 
             // Act
@@ -401,6 +406,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
+                includeDotPaths: false,
             };
 
             // Act
@@ -429,6 +435,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
+                includeDotPaths: false,
             };
 
             // Act
@@ -462,6 +469,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "CACHE_FILE_PATH",
                 cacheMode: "read",
+                includeDotPaths: false,
             };
 
             // Act
@@ -498,6 +506,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "read",
+                includeDotPaths: false,
             };
 
             // Act
@@ -536,6 +545,7 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "read",
+                    includeDotPaths: false,
                 },
                 NullLogger,
             );
@@ -565,6 +575,7 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "write",
+                    includeDotPaths: false,
                 },
                 NullLogger,
             );
@@ -579,31 +590,25 @@ describe("#checkSync", () => {
             const getFilesSpy = jest
                 .spyOn(GetFiles, "default")
                 .mockResolvedValue([]);
+            const options: Options = {
+                includeGlobs: ["glob1", "glob2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+                dryRun: false,
+                autoFix: true,
+                comments: ["//"],
+                json: false,
+                allowEmptyTags: false,
+                cachePath: "",
+                cacheMode: "write",
+                includeDotPaths: false,
+            };
 
             // Act
-            await checkSync(
-                {
-                    includeGlobs: ["glob1", "glob2"],
-                    excludeGlobs: [],
-                    ignoreFiles: [],
-                    dryRun: false,
-                    autoFix: true,
-                    comments: ["//"],
-                    json: false,
-                    allowEmptyTags: false,
-                    cachePath: "",
-                    cacheMode: "write",
-                },
-                NullLogger,
-            );
+            await checkSync(options, NullLogger);
 
             // Assert
-            expect(getFilesSpy).toHaveBeenCalledWith(
-                ["glob1", "glob2"],
-                [],
-                [],
-                NullLogger,
-            );
+            expect(getFilesSpy).toHaveBeenCalledWith(options, NullLogger);
         });
 
         it("should log error when there are no matching files", async () => {
@@ -622,6 +627,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
+                includeDotPaths: false,
             };
 
             // Act
@@ -646,6 +652,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
+                includeDotPaths: false,
             };
 
             // Act
@@ -673,6 +680,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
+                includeDotPaths: false,
             };
 
             // Act
@@ -701,6 +709,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
+                includeDotPaths: false,
             };
 
             // Act
@@ -734,6 +743,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
+                includeDotPaths: false,
             };
 
             // Act
@@ -772,6 +782,7 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
+                includeDotPaths: false,
             };
 
             // Act
@@ -810,6 +821,7 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "write",
+                    includeDotPaths: false,
                 },
                 NullLogger,
             );

--- a/src/__tests__/default-options.test.ts
+++ b/src/__tests__/default-options.test.ts
@@ -42,6 +42,7 @@ describe("defaultOptions", () => {
   "ignoreFiles": [
     ".gitignore",
   ],
+  "includeDotPaths": true,
   "includeGlobs": [
     "/**",
   ],

--- a/src/__tests__/fix-file.test.ts
+++ b/src/__tests__/fix-file.test.ts
@@ -41,6 +41,7 @@ describe("#fixFile", () => {
         allowEmptyTags: false,
         cachePath: "",
         cacheMode: "ignore",
+        includeDotPaths: false,
     };
 
     it("should resolve if there are no mismatches for file", async () => {

--- a/src/__tests__/get-files.test.ts
+++ b/src/__tests__/get-files.test.ts
@@ -30,7 +30,14 @@ describe("#getFiles", () => {
             .mockImplementation((p) => Promise.resolve([...p]));
 
         // Act
-        await getFiles(["pattern1", "pattern2"], [], [], NullLogger);
+        await getFiles(
+            {
+                includeGlobs: ["pattern1", "pattern2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+            } as any,
+            NullLogger,
+        );
 
         // Assert
         expect(globSpy).toHaveBeenCalledWith(
@@ -53,7 +60,14 @@ describe("#getFiles", () => {
         );
 
         // Act
-        await getFiles(["pattern1/*", "pattern2/*"], [], [], NullLogger);
+        await getFiles(
+            {
+                includeGlobs: ["pattern1/*", "pattern2/*"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+            } as any,
+            NullLogger,
+        );
 
         // Assert
         expect(lstatSyncSpy).not.toHaveBeenCalled();
@@ -74,9 +88,11 @@ describe("#getFiles", () => {
 
         // Act
         const result = await getFiles(
-            ["pattern1", "pattern2"],
-            [],
-            [],
+            {
+                includeGlobs: ["pattern1", "pattern2"],
+                excludeGlobs: [],
+                ignoreFiles: [],
+            } as any,
             NullLogger,
         );
 
@@ -99,7 +115,14 @@ describe("#getFiles", () => {
             );
 
         // Act
-        await getFiles([], ["a", "c"], ["ignore-file"], NullLogger);
+        await getFiles(
+            {
+                includeGlobs: [],
+                excludeGlobs: ["a", "c"],
+                ignoreFiles: ["ignore-file"],
+            } as any,
+            NullLogger,
+        );
 
         // Assert
         expect(globSpy).toHaveBeenCalledWith(
@@ -121,9 +144,11 @@ describe("#getFiles", () => {
 
         // Act
         const files = await getFiles(
-            [],
-            ["a", "c"],
-            ["ignore-file"],
+            {
+                includeGlobs: [],
+                excludeGlobs: ["a", "c"],
+                ignoreFiles: ["ignore-file"],
+            } as any,
             NullLogger,
         );
 
@@ -144,7 +169,14 @@ describe("#getFiles", () => {
         const verboseSpy = jest.spyOn(NullLogger, "verbose");
 
         // Act
-        await getFiles([], ["a", "c"], [], NullLogger);
+        await getFiles(
+            {
+                includeGlobs: [],
+                excludeGlobs: ["a", "c"],
+                ignoreFiles: [],
+            } as any,
+            NullLogger,
+        );
 
         // Assert
         expect(verboseSpy).toHaveBeenCalledTimes(3);
@@ -162,7 +194,14 @@ describe("#getFiles", () => {
         );
 
         // Act
-        await getFiles(["b", "d"], ["a", "c"], [], logger);
+        await getFiles(
+            {
+                includeGlobs: ["b", "d"],
+                excludeGlobs: ["a", "c"],
+                ignoreFiles: [],
+            } as any,
+            logger,
+        );
         const log = logger.getLog();
 
         // Assert

--- a/src/__tests__/get-markers-from-files.test.ts
+++ b/src/__tests__/get-markers-from-files.test.ts
@@ -27,6 +27,7 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -66,6 +67,7 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -101,6 +103,7 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -139,6 +142,7 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -198,6 +202,7 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -263,6 +268,7 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -322,6 +328,7 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -371,6 +378,7 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act

--- a/src/__tests__/options-from-args.test.ts
+++ b/src/__tests__/options-from-args.test.ts
@@ -399,4 +399,17 @@ describe("#optionsFromArgs", () => {
             mappings: {},
         });
     });
+
+    it("should set includeDotPaths if args.includeDotPaths is provided", () => {
+        // Arrange
+        const args: any = {
+            includeDotPaths: true,
+        };
+
+        // Act
+        const result = optionsFromArgs(args);
+
+        // Assert
+        expect(result.includeDotPaths).toBe(true);
+    });
 });

--- a/src/__tests__/parse-file.test.ts
+++ b/src/__tests__/parse-file.test.ts
@@ -62,6 +62,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -88,6 +89,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -126,6 +128,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -160,6 +163,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -205,6 +209,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -246,6 +251,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -293,6 +299,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -375,6 +382,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -442,6 +450,7 @@ describe("#parseFile", () => {
             allowEmptyTags: true,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -505,6 +514,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -560,6 +570,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -613,6 +624,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
 
         // Act
@@ -659,6 +671,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -716,6 +729,7 @@ describe("#parseFile", () => {
             allowEmptyTags: true,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -795,6 +809,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -855,6 +870,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -914,6 +930,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -1022,6 +1039,7 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
+            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];

--- a/src/build-cache.ts
+++ b/src/build-cache.ts
@@ -18,8 +18,7 @@ export default async function buildCache(
     options: Options,
     log: ILog,
 ): Promise<MarkerCache> {
-    const {includeGlobs, excludeGlobs, ignoreFiles} = options;
-    const files = await getFiles(includeGlobs, excludeGlobs, ignoreFiles, log);
+    const files = await getFiles(options, log);
 
     if (files.length === 0) {
         throw new ExitError("No matching files", ExitCode.NO_FILES);

--- a/src/checksync.schema.json
+++ b/src/checksync.schema.json
@@ -51,6 +51,11 @@
             "uniqueItems": true,
             "minLength": 0
         },
+        "includeDotPaths": {
+            "description": "When true, checksync will include paths that start with a dot when parsing includeGlobs, e.g. .gitignore",
+            "type": "boolean",
+            "default": true
+        },
         "includeGlobs": {
             "description": "An array of globs that identify files to include in the checks",
             "type": "array",

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -12,6 +12,7 @@ const defaultOptions: Options = {
     includeGlobs: [`${process.cwd()}**`],
     cachePath: "cache.json",
     cacheMode: "ignore",
+    includeDotPaths: true,
 };
 
 export default defaultOptions;

--- a/src/get-files.ts
+++ b/src/get-files.ts
@@ -3,7 +3,7 @@ import path from "path";
 import fs from "fs";
 import ignoreFileGlobsToAllowPredicate from "./ignore-file-globs-to-allow-predicate";
 
-import {ILog} from "./types";
+import {ILog, Options} from "./types";
 
 /**
  * Expand the given globs and ignore files into a list of files.
@@ -14,15 +14,13 @@ import {ILog} from "./types";
  * @param {ILog} log A log to record things
  */
 export default async function getFiles(
-    includeGlobs: ReadonlyArray<string>,
-    excludeGlobs: ReadonlyArray<string>,
-    ignoreFileGlobs: ReadonlyArray<string>,
+    {includeGlobs, excludeGlobs, ignoreFiles, includeDotPaths}: Options,
     log: ILog,
 ): Promise<Array<string>> {
     // We turn all the ignore files we're using into a single predicate that
     // returns true if a file is allowed, or false if it is ignored.
     const allowPredicate = await ignoreFileGlobsToAllowPredicate(
-        ignoreFileGlobs,
+        ignoreFiles,
         log,
     );
 
@@ -55,6 +53,7 @@ export default async function getFiles(
     const paths = await glob([...includeGlobs], {
         onlyFiles: true,
         absolute: true,
+        dot: includeDotPaths,
         ignore: excludeGlobs as Array<string>, // remove readonly-ness
     });
     const sortedPaths = paths

--- a/src/options-from-args.ts
+++ b/src/options-from-args.ts
@@ -53,6 +53,10 @@ export const optionsFromArgs = (args: Arguments<any>): Partial<Options> => {
         options.allowEmptyTags = !!args.allowEmptyTags;
     }
 
+    if (args.includeDotPaths != null) {
+        options.includeDotPaths = !!args.includeDotPaths;
+    }
+
     if (args.outputCache != null) {
         // Only overwrite the path if one was given, otherwise we'll let
         // defaults handle that.

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -18,6 +18,7 @@ export const parseArgs = (log: ILog) =>
             "version",
             "json",
             "allowEmptyTags",
+            "includeDotPaths",
         ])
         .string([
             "cwd",
@@ -30,6 +31,13 @@ export const parseArgs = (log: ILog) =>
             "fromCache",
             "migrate",
         ])
+        .option("includeDotPaths", {
+            type: "boolean",
+            description:
+                "Include paths that begin with a dot, e.g. '.gitignore' when parsing `includeGlobs`.",
+            default: true,
+            conflicts: ["help", "version", "fromCache"],
+        })
         .option("outputCache", {
             type: "string",
             description: "Path to the output cache file.",
@@ -46,6 +54,7 @@ export const parseArgs = (log: ILog) =>
                 "outputCache",
                 "help",
                 "version",
+                "includeDotPaths",
             ],
         })
         .option("migrate", {
@@ -65,6 +74,7 @@ export const parseArgs = (log: ILog) =>
         .alias("allowEmptyTags", ["a", "allow-empty-tags"])
         .alias("outputCache", ["o", "output-cache"])
         .alias("fromCache", ["f", "use-cache"])
+        .alias("includeDotPaths", ["d", "include-dot-paths"])
         .strictOptions()
         .fail((msg, err, yargs) => {
             log.error(msg);

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,11 @@ export type Options = {
      */
     includeGlobs: ReadonlyArray<string>;
     /**
+     * Include paths that begin with a dot, e.g. ".gitignore" when parsing
+     * `includeGlobs`.
+     */
+    includeDotPaths: boolean;
+    /**
      * The globs for files that are to be ignored.
      */
     excludeGlobs: ReadonlyArray<string>;


### PR DESCRIPTION
## Summary:
This makes it so that dot paths like `./.eslintrc` are included when parsing the globs of what files to include. This can be disabled with configuration or arguments via the `includeDotPaths` option.

Issue: Closes #2117

## Test plan:
`pnpm test`

I've added a new ingegration test that would fail if `includeDotPaths` were false.