### PR TITLE
[🔥AUDIT🔥] Remove arg default for includeDotPaths

### DIFF
--- a/.changeset/soft-points-poke.md
+++ b/.changeset/soft-points-poke.md
@@ -1,0 +1,5 @@
+---
+"checksync": patch
+---
+
+Fix --help

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -34,8 +34,7 @@ export const parseArgs = (log: ILog) =>
         .option("includeDotPaths", {
             type: "boolean",
             description:
-                "Include paths that begin with a dot, e.g. '.gitignore' when parsing `includeGlobs`.",
-            default: true,
+                "Include paths that begin with a dot, e.g. '.gitignore' when parsing `includeGlobs`. This is default behavior.",
             conflicts: ["help", "version", "fromCache"],
         })
         .option("outputCache", {


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This was preventing `checksync --help` from working, as the default is seen as the arg being used and so then it says it can't be used with `--help`. We want to still prevent them being combined as it doesn't make sense, so we remove the default for the arg and instead rely on our internal default logic to handle setting that default value. This is what we want anyway as we don't want the config to be overridden by the default arg.

Issue: XXX-XXXX

## Test plan:
`pnpm test`