### PR TITLE
[🔥AUDIT🔥] Remove includeDotPaths and update help instead

### DIFF
--- a/.changeset/clean-moose-taste.md
+++ b/.changeset/clean-moose-taste.md
@@ -2,4 +2,4 @@
 "checksync": major
 ---
 
-Make includeDotPaths default to false and perma-exclude .git
+Removed the `includeDotPaths` config option and associated argument. It was a mistake. If you need a path that starts with a `.` to be included, explicitly list it in the `includeGlobs` configuration or the paths passed to the CLI command.

--- a/.changeset/clean-moose-taste.md
+++ b/.changeset/clean-moose-taste.md
@@ -1,0 +1,5 @@
+---
+"checksync": major
+---
+
+Make includeDotPaths default to false and perma-exclude .git

--- a/__examples__/dot_paths_with_correct_checksum/.checkme1
+++ b/__examples__/dot_paths_with_correct_checksum/.checkme1
@@ -1,3 +1,0 @@
-// sync-start:update_me 1473833596 __examples__/dot_paths_with_correct_checksum/.checkme2
-Perhaps an ignore file. Who knows.
-// sync-end:update_me

--- a/__examples__/dot_paths_with_correct_checksum/.checkme2
+++ b/__examples__/dot_paths_with_correct_checksum/.checkme2
@@ -1,3 +1,0 @@
-// sync-start:update_me 455799753 __examples__/dot_paths_with_correct_checksum/.checkme1
-Perhaps another ignore file or some config file. Who knows.
-// sync-end:update_me

--- a/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -46,7 +46,11 @@ Where:
     <include_paths>    are space-separated paths and glob patterns
                        for identifying files to check.
                        Defaults to all files below the current working
-                       directory.
+                       directory. Note that files and folders that start
+                       with a period are not automatically parsed; they
+                       must be explicitly included in the <include_paths>
+                       argument or corresponding includeGlobs configuration
+                       value.
 
 Arguments
 

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -65,7 +65,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -164,7 +163,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -260,7 +258,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -410,7 +407,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/checksums_need_updating.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -508,7 +504,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -610,7 +605,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -714,7 +708,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -881,7 +874,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/content_after_start.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -976,7 +968,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1056,7 +1047,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1136,7 +1126,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1219,7 +1208,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/correct_checksums.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1314,7 +1302,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1401,7 +1388,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1488,7 +1474,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1591,7 +1576,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/directory_target.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -1618,343 +1602,6 @@ Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/directory_target/example.js"
 ]
 Info     Cache written to ROOT_DIR/.integrationtests/directory_target.json"
-`;
-
-exports[`Integration Tests (see __examples__ folder) Example dot_paths_with_correct_checksum should report example dot_paths_with_correct_checksum to match snapshot for scenario autofix 1`] = `
-"Verbose  Options from arguments: {
-  "includeGlobs": [
-    "**/dot_paths_with_correct_checksum/**"
-  ],
-  "autoFix": true,
-  "dryRun": true,
-  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
-  "cacheMode": "read"
-}
-Verbose  Looking for configuration file based on root marker...
-Verbose  Checking ROOT_DIR/.checksyncrc...
-Verbose  Checking ROOT_DIR/.checksyncrc.json...
-Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
-Verbose  Changing working directory to ROOT_DIR
-Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
-Verbose  Validating configuration
-Verbose  Configuration is valid
-Verbose  Options from config: {
-  "$schema": "./src/checksync.schema.json",
-  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
-  "autoFix": false,
-  "comments": [
-    "//",
-    "#",
-    "{/*"
-  ],
-  "dryRun": false,
-  "excludeGlobs": [
-    "**/excluded/**"
-  ],
-  "ignoreFiles": [
-    "**/ignore-file.txt"
-  ],
-  "json": false,
-  "migration": {
-    "mode": "missing",
-    "mappings": {
-      "__examples__/migrate_missing_target/": "https://example.com/1/",
-      "__examples__/migrate_all/": "https://example.com/2/",
-      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
-    }
-  }
-}
-Verbose  Combined options with defaults: {
-  "autoFix": true,
-  "json": false,
-  "allowEmptyTags": false,
-  "comments": [
-    "//",
-    "#",
-    "{/*"
-  ],
-  "excludeGlobs": [
-    "**/excluded/**"
-  ],
-  "dryRun": true,
-  "ignoreFiles": [
-    "**/ignore-file.txt"
-  ],
-  "includeGlobs": [
-    "**/dot_paths_with_correct_checksum/**"
-  ],
-  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
-  "cacheMode": "read",
-  "includeDotPaths": true,
-  "$schema": "./src/checksync.schema.json",
-  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
-  "migration": {
-    "mode": "missing",
-    "mappings": {
-      "__examples__/migrate_missing_target/": "https://example.com/1/",
-      "__examples__/migrate_all/": "https://example.com/2/",
-      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
-    }
-  }
-}
-Info     DRY-RUN: Files will not be modified
-Info     Loading cache from ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json
-🎉  Everything is in sync!"
-`;
-
-exports[`Integration Tests (see __examples__ folder) Example dot_paths_with_correct_checksum should report example dot_paths_with_correct_checksum to match snapshot for scenario check-only 1`] = `
-"Verbose  Options from arguments: {
-  "includeGlobs": [
-    "**/dot_paths_with_correct_checksum/**"
-  ],
-  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
-  "cacheMode": "read"
-}
-Verbose  Looking for configuration file based on root marker...
-Verbose  Checking ROOT_DIR/.checksyncrc...
-Verbose  Checking ROOT_DIR/.checksyncrc.json...
-Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
-Verbose  Changing working directory to ROOT_DIR
-Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
-Verbose  Validating configuration
-Verbose  Configuration is valid
-Verbose  Options from config: {
-  "$schema": "./src/checksync.schema.json",
-  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
-  "autoFix": false,
-  "comments": [
-    "//",
-    "#",
-    "{/*"
-  ],
-  "dryRun": false,
-  "excludeGlobs": [
-    "**/excluded/**"
-  ],
-  "ignoreFiles": [
-    "**/ignore-file.txt"
-  ],
-  "json": false,
-  "migration": {
-    "mode": "missing",
-    "mappings": {
-      "__examples__/migrate_missing_target/": "https://example.com/1/",
-      "__examples__/migrate_all/": "https://example.com/2/",
-      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
-    }
-  }
-}
-Verbose  Combined options with defaults: {
-  "autoFix": false,
-  "json": false,
-  "allowEmptyTags": false,
-  "comments": [
-    "//",
-    "#",
-    "{/*"
-  ],
-  "excludeGlobs": [
-    "**/excluded/**"
-  ],
-  "dryRun": false,
-  "ignoreFiles": [
-    "**/ignore-file.txt"
-  ],
-  "includeGlobs": [
-    "**/dot_paths_with_correct_checksum/**"
-  ],
-  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
-  "cacheMode": "read",
-  "includeDotPaths": true,
-  "$schema": "./src/checksync.schema.json",
-  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
-  "migration": {
-    "mode": "missing",
-    "mappings": {
-      "__examples__/migrate_missing_target/": "https://example.com/1/",
-      "__examples__/migrate_all/": "https://example.com/2/",
-      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
-    }
-  }
-}
-Info     Loading cache from ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json
-🎉  Everything is in sync!"
-`;
-
-exports[`Integration Tests (see __examples__ folder) Example dot_paths_with_correct_checksum should report example dot_paths_with_correct_checksum to match snapshot for scenario json-check-only 1`] = `
-"Verbose  Options from arguments: {
-  "includeGlobs": [
-    "**/dot_paths_with_correct_checksum/**"
-  ],
-  "json": true,
-  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
-  "cacheMode": "read"
-}
-Verbose  Looking for configuration file based on root marker...
-Verbose  Checking ROOT_DIR/.checksyncrc...
-Verbose  Checking ROOT_DIR/.checksyncrc.json...
-Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
-Verbose  Changing working directory to ROOT_DIR
-Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
-Verbose  Validating configuration
-Verbose  Configuration is valid
-Verbose  Options from config: {
-  "$schema": "./src/checksync.schema.json",
-  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
-  "autoFix": false,
-  "comments": [
-    "//",
-    "#",
-    "{/*"
-  ],
-  "dryRun": false,
-  "excludeGlobs": [
-    "**/excluded/**"
-  ],
-  "ignoreFiles": [
-    "**/ignore-file.txt"
-  ],
-  "json": false,
-  "migration": {
-    "mode": "missing",
-    "mappings": {
-      "__examples__/migrate_missing_target/": "https://example.com/1/",
-      "__examples__/migrate_all/": "https://example.com/2/",
-      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
-    }
-  }
-}
-Verbose  Combined options with defaults: {
-  "autoFix": false,
-  "json": true,
-  "allowEmptyTags": false,
-  "comments": [
-    "//",
-    "#",
-    "{/*"
-  ],
-  "excludeGlobs": [
-    "**/excluded/**"
-  ],
-  "dryRun": false,
-  "ignoreFiles": [
-    "**/ignore-file.txt"
-  ],
-  "includeGlobs": [
-    "**/dot_paths_with_correct_checksum/**"
-  ],
-  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
-  "cacheMode": "read",
-  "includeDotPaths": true,
-  "$schema": "./src/checksync.schema.json",
-  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
-  "migration": {
-    "mode": "missing",
-    "mappings": {
-      "__examples__/migrate_missing_target/": "https://example.com/1/",
-      "__examples__/migrate_all/": "https://example.com/2/",
-      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
-    }
-  }
-}
-Info     Loading cache from ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json
-{
-    "version": "0.0.0",
-    "launchString": "checksync -u ",
-    "files": {}
-}"
-`;
-
-exports[`Integration Tests (see __examples__ folder) Example dot_paths_with_correct_checksum should report example dot_paths_with_correct_checksum to match snapshot for scenario undefined 1`] = `
-"Verbose  Options from arguments: {
-  "includeGlobs": [
-    "**/dot_paths_with_correct_checksum/**"
-  ],
-  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
-  "cacheMode": "write"
-}
-Verbose  Looking for configuration file based on root marker...
-Verbose  Checking ROOT_DIR/.checksyncrc...
-Verbose  Checking ROOT_DIR/.checksyncrc.json...
-Verbose  Found configuration file: ROOT_DIR/.checksyncrc.json
-Verbose  Changing working directory to ROOT_DIR
-Verbose  Loading configuration from ROOT_DIR/.checksyncrc.json
-Verbose  Validating configuration
-Verbose  Configuration is valid
-Verbose  Options from config: {
-  "$schema": "./src/checksync.schema.json",
-  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
-  "autoFix": false,
-  "comments": [
-    "//",
-    "#",
-    "{/*"
-  ],
-  "dryRun": false,
-  "excludeGlobs": [
-    "**/excluded/**"
-  ],
-  "ignoreFiles": [
-    "**/ignore-file.txt"
-  ],
-  "json": false,
-  "migration": {
-    "mode": "missing",
-    "mappings": {
-      "__examples__/migrate_missing_target/": "https://example.com/1/",
-      "__examples__/migrate_all/": "https://example.com/2/",
-      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
-    }
-  }
-}
-Verbose  Combined options with defaults: {
-  "autoFix": false,
-  "json": false,
-  "allowEmptyTags": false,
-  "comments": [
-    "//",
-    "#",
-    "{/*"
-  ],
-  "excludeGlobs": [
-    "**/excluded/**"
-  ],
-  "dryRun": false,
-  "ignoreFiles": [
-    "**/ignore-file.txt"
-  ],
-  "includeGlobs": [
-    "**/dot_paths_with_correct_checksum/**"
-  ],
-  "cachePath": "ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json",
-  "cacheMode": "write",
-  "includeDotPaths": true,
-  "$schema": "./src/checksync.schema.json",
-  "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
-  "migration": {
-    "mode": "missing",
-    "mappings": {
-      "__examples__/migrate_missing_target/": "https://example.com/1/",
-      "__examples__/migrate_all/": "https://example.com/2/",
-      "__examples__/migrate_missing_target/subfolder/": "https://example.com/2/"
-    }
-  }
-}
-Verbose  Ignore files: [
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/ignore-file.txt",
-    "ROOT_DIR/__examples__/ignore_files_at_different_depths/some/ignore-file.txt"
-]
-Verbose  Include globs: [
-    "**/dot_paths_with_correct_checksum/**"
-]
-Verbose  Exclude globs: [
-    "**/excluded/**"
-]
-Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/dot_paths_with_correct_checksum/.checkme1",
-    "ROOT_DIR/__examples__/dot_paths_with_correct_checksum/.checkme2"
-]
-Info     Cache written to ROOT_DIR/.integrationtests/dot_paths_with_correct_checksum.json"
 `;
 
 exports[`Integration Tests (see __examples__ folder) Example duplicate-target should report example duplicate-target to match snapshot for scenario autofix 1`] = `
@@ -2022,7 +1669,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2117,7 +1763,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2212,7 +1857,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2359,7 +2003,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/duplicate_target.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2453,7 +2096,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2538,7 +2180,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2623,7 +2264,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2718,7 +2358,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/empty_tag.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2812,7 +2451,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2897,7 +2535,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -2982,7 +2619,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3077,7 +2713,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/end_with_no_start.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3170,7 +2805,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3250,7 +2884,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3330,7 +2963,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3409,7 +3041,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/excluded.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3500,7 +3131,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3585,7 +3215,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3670,7 +3299,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3765,7 +3393,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/ignore_files_at_different_depths.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3865,7 +3492,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -3957,7 +3583,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4049,7 +3674,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4170,7 +3794,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_end.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4264,7 +3887,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4361,7 +3983,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4458,7 +4079,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4597,7 +4217,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/malformed_start.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4696,7 +4315,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4797,7 +4415,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -4889,7 +4506,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5011,7 +4627,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_all.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5105,7 +4720,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_missing_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5200,7 +4814,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_missing_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5290,7 +4903,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_missing_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5406,7 +5018,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/migrate_missing_target.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5499,7 +5110,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5586,7 +5196,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5673,7 +5282,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5776,7 +5384,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/missing_target.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5869,7 +5476,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -5954,7 +5560,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6039,7 +5644,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6134,7 +5738,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_back_reference.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6228,7 +5831,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6321,7 +5923,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6411,7 +6012,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6529,7 +6129,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_checksums.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6623,7 +6222,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6713,7 +6311,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6806,7 +6403,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -6916,7 +6512,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/no_self_reference.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7009,7 +6604,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7098,7 +6692,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7185,7 +6778,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7286,7 +6878,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_broken.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7379,7 +6970,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7459,7 +7049,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7539,7 +7128,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7622,7 +7210,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/remote_tags_match.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7716,7 +7303,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7804,7 +7390,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7892,7 +7477,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "read",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {
@@ -7997,7 +7581,6 @@ Verbose  Combined options with defaults: {
   ],
   "cachePath": "ROOT_DIR/.integrationtests/unterminated_marker.json",
   "cacheMode": "write",
-  "includeDotPaths": true,
   "$schema": "./src/checksync.schema.json",
   "$comment": "This is the config file for our integration tests. By not specifying it directly, we also test configuration file discovery.",
   "migration": {

--- a/src/__tests__/check-sync.test.ts
+++ b/src/__tests__/check-sync.test.ts
@@ -39,7 +39,6 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "ignore",
-                    includeDotPaths: false,
                 },
                 NullLogger,
             );
@@ -56,25 +55,31 @@ describe("#checkSync", () => {
             const getFilesSpy = jest
                 .spyOn(GetFiles, "default")
                 .mockResolvedValue([]);
-            const options: Options = {
-                includeGlobs: ["glob1", "glob2"],
-                excludeGlobs: [],
-                ignoreFiles: [],
-                dryRun: false,
-                autoFix: true,
-                comments: ["//"],
-                json: false,
-                allowEmptyTags: false,
-                cachePath: "",
-                cacheMode: "ignore",
-                includeDotPaths: false,
-            };
 
             // Act
-            await checkSync(options, NullLogger);
+            await checkSync(
+                {
+                    includeGlobs: ["glob1", "glob2"],
+                    excludeGlobs: [],
+                    ignoreFiles: [],
+                    dryRun: false,
+                    autoFix: true,
+                    comments: ["//"],
+                    json: false,
+                    allowEmptyTags: false,
+                    cachePath: "",
+                    cacheMode: "ignore",
+                },
+                NullLogger,
+            );
 
             // Assert
-            expect(getFilesSpy).toHaveBeenCalledWith(options, NullLogger);
+            expect(getFilesSpy).toHaveBeenCalledWith(
+                ["glob1", "glob2"],
+                [],
+                [],
+                NullLogger,
+            );
         });
 
         it("should log error when there are no matching files", async () => {
@@ -93,7 +98,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
-                includeDotPaths: false,
             };
 
             // Act
@@ -118,7 +122,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
-                includeDotPaths: false,
             };
 
             // Act
@@ -146,7 +149,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
-                includeDotPaths: false,
             };
 
             // Act
@@ -175,7 +177,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
-                includeDotPaths: false,
             };
 
             // Act
@@ -209,7 +210,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
-                includeDotPaths: false,
             };
 
             // Act
@@ -248,7 +248,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
-                includeDotPaths: false,
             };
 
             // Act
@@ -290,7 +289,6 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "ignore",
-                    includeDotPaths: false,
                 },
                 NullLogger,
             );
@@ -320,7 +318,6 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "read",
-                    includeDotPaths: false,
                 },
                 NullLogger,
             );
@@ -350,7 +347,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "read",
-                includeDotPaths: false,
             };
 
             // Act
@@ -378,7 +374,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "read",
-                includeDotPaths: false,
             };
 
             // Act
@@ -406,7 +401,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
-                includeDotPaths: false,
             };
 
             // Act
@@ -435,7 +429,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "ignore",
-                includeDotPaths: false,
             };
 
             // Act
@@ -469,7 +462,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "CACHE_FILE_PATH",
                 cacheMode: "read",
-                includeDotPaths: false,
             };
 
             // Act
@@ -506,7 +498,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "read",
-                includeDotPaths: false,
             };
 
             // Act
@@ -545,7 +536,6 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "read",
-                    includeDotPaths: false,
                 },
                 NullLogger,
             );
@@ -575,7 +565,6 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "write",
-                    includeDotPaths: false,
                 },
                 NullLogger,
             );
@@ -590,25 +579,31 @@ describe("#checkSync", () => {
             const getFilesSpy = jest
                 .spyOn(GetFiles, "default")
                 .mockResolvedValue([]);
-            const options: Options = {
-                includeGlobs: ["glob1", "glob2"],
-                excludeGlobs: [],
-                ignoreFiles: [],
-                dryRun: false,
-                autoFix: true,
-                comments: ["//"],
-                json: false,
-                allowEmptyTags: false,
-                cachePath: "",
-                cacheMode: "write",
-                includeDotPaths: false,
-            };
 
             // Act
-            await checkSync(options, NullLogger);
+            await checkSync(
+                {
+                    includeGlobs: ["glob1", "glob2"],
+                    excludeGlobs: [],
+                    ignoreFiles: [],
+                    dryRun: false,
+                    autoFix: true,
+                    comments: ["//"],
+                    json: false,
+                    allowEmptyTags: false,
+                    cachePath: "",
+                    cacheMode: "write",
+                },
+                NullLogger,
+            );
 
             // Assert
-            expect(getFilesSpy).toHaveBeenCalledWith(options, NullLogger);
+            expect(getFilesSpy).toHaveBeenCalledWith(
+                ["glob1", "glob2"],
+                [],
+                [],
+                NullLogger,
+            );
         });
 
         it("should log error when there are no matching files", async () => {
@@ -627,7 +622,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
-                includeDotPaths: false,
             };
 
             // Act
@@ -652,7 +646,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
-                includeDotPaths: false,
             };
 
             // Act
@@ -680,7 +673,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
-                includeDotPaths: false,
             };
 
             // Act
@@ -709,7 +701,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
-                includeDotPaths: false,
             };
 
             // Act
@@ -743,7 +734,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
-                includeDotPaths: false,
             };
 
             // Act
@@ -782,7 +772,6 @@ describe("#checkSync", () => {
                 allowEmptyTags: false,
                 cachePath: "",
                 cacheMode: "write",
-                includeDotPaths: false,
             };
 
             // Act
@@ -821,7 +810,6 @@ describe("#checkSync", () => {
                     allowEmptyTags: false,
                     cachePath: "",
                     cacheMode: "write",
-                    includeDotPaths: false,
                 },
                 NullLogger,
             );

--- a/src/__tests__/default-options.test.ts
+++ b/src/__tests__/default-options.test.ts
@@ -42,7 +42,6 @@ describe("defaultOptions", () => {
   "ignoreFiles": [
     ".gitignore",
   ],
-  "includeDotPaths": true,
   "includeGlobs": [
     "/**",
   ],

--- a/src/__tests__/fix-file.test.ts
+++ b/src/__tests__/fix-file.test.ts
@@ -41,7 +41,6 @@ describe("#fixFile", () => {
         allowEmptyTags: false,
         cachePath: "",
         cacheMode: "ignore",
-        includeDotPaths: false,
     };
 
     it("should resolve if there are no mismatches for file", async () => {

--- a/src/__tests__/get-files.test.ts
+++ b/src/__tests__/get-files.test.ts
@@ -30,14 +30,7 @@ describe("#getFiles", () => {
             .mockImplementation((p) => Promise.resolve([...p]));
 
         // Act
-        await getFiles(
-            {
-                includeGlobs: ["pattern1", "pattern2"],
-                excludeGlobs: [],
-                ignoreFiles: [],
-            } as any,
-            NullLogger,
-        );
+        await getFiles(["pattern1", "pattern2"], [], [], NullLogger);
 
         // Assert
         expect(globSpy).toHaveBeenCalledWith(
@@ -60,14 +53,7 @@ describe("#getFiles", () => {
         );
 
         // Act
-        await getFiles(
-            {
-                includeGlobs: ["pattern1/*", "pattern2/*"],
-                excludeGlobs: [],
-                ignoreFiles: [],
-            } as any,
-            NullLogger,
-        );
+        await getFiles(["pattern1/*", "pattern2/*"], [], [], NullLogger);
 
         // Assert
         expect(lstatSyncSpy).not.toHaveBeenCalled();
@@ -88,11 +74,9 @@ describe("#getFiles", () => {
 
         // Act
         const result = await getFiles(
-            {
-                includeGlobs: ["pattern1", "pattern2"],
-                excludeGlobs: [],
-                ignoreFiles: [],
-            } as any,
+            ["pattern1", "pattern2"],
+            [],
+            [],
             NullLogger,
         );
 
@@ -115,14 +99,7 @@ describe("#getFiles", () => {
             );
 
         // Act
-        await getFiles(
-            {
-                includeGlobs: [],
-                excludeGlobs: ["a", "c"],
-                ignoreFiles: ["ignore-file"],
-            } as any,
-            NullLogger,
-        );
+        await getFiles([], ["a", "c"], ["ignore-file"], NullLogger);
 
         // Assert
         expect(globSpy).toHaveBeenCalledWith(
@@ -144,11 +121,9 @@ describe("#getFiles", () => {
 
         // Act
         const files = await getFiles(
-            {
-                includeGlobs: [],
-                excludeGlobs: ["a", "c"],
-                ignoreFiles: ["ignore-file"],
-            } as any,
+            [],
+            ["a", "c"],
+            ["ignore-file"],
             NullLogger,
         );
 
@@ -169,14 +144,7 @@ describe("#getFiles", () => {
         const verboseSpy = jest.spyOn(NullLogger, "verbose");
 
         // Act
-        await getFiles(
-            {
-                includeGlobs: [],
-                excludeGlobs: ["a", "c"],
-                ignoreFiles: [],
-            } as any,
-            NullLogger,
-        );
+        await getFiles([], ["a", "c"], [], NullLogger);
 
         // Assert
         expect(verboseSpy).toHaveBeenCalledTimes(3);
@@ -194,14 +162,7 @@ describe("#getFiles", () => {
         );
 
         // Act
-        await getFiles(
-            {
-                includeGlobs: ["b", "d"],
-                excludeGlobs: ["a", "c"],
-                ignoreFiles: [],
-            } as any,
-            logger,
-        );
+        await getFiles(["b", "d"], ["a", "c"], [], logger);
         const log = logger.getLog();
 
         // Assert

--- a/src/__tests__/get-markers-from-files.test.ts
+++ b/src/__tests__/get-markers-from-files.test.ts
@@ -27,7 +27,6 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -67,7 +66,6 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -103,7 +101,6 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -142,7 +139,6 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -202,7 +198,6 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -268,7 +263,6 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -328,7 +322,6 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -378,7 +371,6 @@ describe("#fromFiles", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act

--- a/src/__tests__/help.test.ts
+++ b/src/__tests__/help.test.ts
@@ -60,7 +60,11 @@ Where:
     <include_paths>    are space-separated paths and glob patterns
                        for identifying files to check.
                        Defaults to all files below the current working
-                       directory.
+                       directory. Note that files and folders that start
+                       with a period are not automatically parsed; they
+                       must be explicitly included in the <include_paths>
+                       argument or corresponding includeGlobs configuration
+                       value.
 
 Arguments
 

--- a/src/__tests__/options-from-args.test.ts
+++ b/src/__tests__/options-from-args.test.ts
@@ -399,17 +399,4 @@ describe("#optionsFromArgs", () => {
             mappings: {},
         });
     });
-
-    it("should set includeDotPaths if args.includeDotPaths is provided", () => {
-        // Arrange
-        const args: any = {
-            includeDotPaths: true,
-        };
-
-        // Act
-        const result = optionsFromArgs(args);
-
-        // Assert
-        expect(result.includeDotPaths).toBe(true);
-    });
 });

--- a/src/__tests__/parse-file.test.ts
+++ b/src/__tests__/parse-file.test.ts
@@ -62,7 +62,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -89,7 +88,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -128,7 +126,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -163,7 +160,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -209,7 +205,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -251,7 +246,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -299,7 +293,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -382,7 +375,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -450,7 +442,6 @@ describe("#parseFile", () => {
             allowEmptyTags: true,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -514,7 +505,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -570,7 +560,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -624,7 +613,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
 
         // Act
@@ -671,7 +659,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -729,7 +716,6 @@ describe("#parseFile", () => {
             allowEmptyTags: true,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -809,7 +795,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -870,7 +855,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -930,7 +914,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];
@@ -1039,7 +1022,6 @@ describe("#parseFile", () => {
             allowEmptyTags: false,
             cachePath: "",
             cacheMode: "ignore",
-            includeDotPaths: false,
         };
         const promise = parseFile(options, "root.path/file.js", false);
         const addMarkerCb = markerParserSpy.mock.calls[0][1];

--- a/src/build-cache.ts
+++ b/src/build-cache.ts
@@ -18,7 +18,8 @@ export default async function buildCache(
     options: Options,
     log: ILog,
 ): Promise<MarkerCache> {
-    const files = await getFiles(options, log);
+    const {includeGlobs, excludeGlobs, ignoreFiles} = options;
+    const files = await getFiles(includeGlobs, excludeGlobs, ignoreFiles, log);
 
     if (files.length === 0) {
         throw new ExitError("No matching files", ExitCode.NO_FILES);

--- a/src/checksync.schema.json
+++ b/src/checksync.schema.json
@@ -51,11 +51,6 @@
             "uniqueItems": true,
             "minLength": 0
         },
-        "includeDotPaths": {
-            "description": "When true, checksync will include paths that start with a dot when parsing includeGlobs, e.g. .gitignore",
-            "type": "boolean",
-            "default": true
-        },
         "includeGlobs": {
             "description": "An array of globs that identify files to include in the checks",
             "type": "array",

--- a/src/default-options.ts
+++ b/src/default-options.ts
@@ -12,7 +12,6 @@ const defaultOptions: Options = {
     includeGlobs: [`${process.cwd()}**`],
     cachePath: "cache.json",
     cacheMode: "ignore",
-    includeDotPaths: true,
 };
 
 export default defaultOptions;

--- a/src/get-files.ts
+++ b/src/get-files.ts
@@ -3,7 +3,7 @@ import path from "path";
 import fs from "fs";
 import ignoreFileGlobsToAllowPredicate from "./ignore-file-globs-to-allow-predicate";
 
-import {ILog, Options} from "./types";
+import {ILog} from "./types";
 
 /**
  * Expand the given globs and ignore files into a list of files.
@@ -14,13 +14,15 @@ import {ILog, Options} from "./types";
  * @param {ILog} log A log to record things
  */
 export default async function getFiles(
-    {includeGlobs, excludeGlobs, ignoreFiles, includeDotPaths}: Options,
+    includeGlobs: ReadonlyArray<string>,
+    excludeGlobs: ReadonlyArray<string>,
+    ignoreFileGlobs: ReadonlyArray<string>,
     log: ILog,
 ): Promise<Array<string>> {
     // We turn all the ignore files we're using into a single predicate that
     // returns true if a file is allowed, or false if it is ignored.
     const allowPredicate = await ignoreFileGlobsToAllowPredicate(
-        ignoreFiles,
+        ignoreFileGlobs,
         log,
     );
 
@@ -53,7 +55,6 @@ export default async function getFiles(
     const paths = await glob([...includeGlobs], {
         onlyFiles: true,
         absolute: true,
-        dot: includeDotPaths,
         ignore: excludeGlobs as Array<string>, // remove readonly-ness
     });
     const sortedPaths = paths

--- a/src/help.ts
+++ b/src/help.ts
@@ -48,7 +48,11 @@ Where:
     \`<include_paths>\`    are space-separated paths and glob patterns
                        for identifying files to check.
                        Defaults to all files below the current working
-                       directory.
+                       directory. Note that files and folders that start
+                       with a period are not automatically parsed; they
+                       must be explicitly included in the \`<include_paths>\`
+                       argument or corresponding \`includeGlobs\` configuration
+                       value.
 
 ## Arguments
 

--- a/src/options-from-args.ts
+++ b/src/options-from-args.ts
@@ -53,10 +53,6 @@ export const optionsFromArgs = (args: Arguments<any>): Partial<Options> => {
         options.allowEmptyTags = !!args.allowEmptyTags;
     }
 
-    if (args.includeDotPaths != null) {
-        options.includeDotPaths = !!args.includeDotPaths;
-    }
-
     if (args.outputCache != null) {
         // Only overwrite the path if one was given, otherwise we'll let
         // defaults handle that.

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -34,7 +34,8 @@ export const parseArgs = (log: ILog) =>
         .option("includeDotPaths", {
             type: "boolean",
             description:
-                "Include paths that begin with a dot, e.g. '.gitignore' when parsing `includeGlobs`. This is default behavior.",
+                "Include paths that begin with a dot, e.g. '.gitignore' when parsing `includeGlobs`.",
+            default: true,
             conflicts: ["help", "version", "fromCache"],
         })
         .option("outputCache", {

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -18,7 +18,6 @@ export const parseArgs = (log: ILog) =>
             "version",
             "json",
             "allowEmptyTags",
-            "includeDotPaths",
         ])
         .string([
             "cwd",
@@ -31,13 +30,6 @@ export const parseArgs = (log: ILog) =>
             "fromCache",
             "migrate",
         ])
-        .option("includeDotPaths", {
-            type: "boolean",
-            description:
-                "Include paths that begin with a dot, e.g. '.gitignore' when parsing `includeGlobs`.",
-            default: true,
-            conflicts: ["help", "version", "fromCache"],
-        })
         .option("outputCache", {
             type: "string",
             description: "Path to the output cache file.",
@@ -54,7 +46,6 @@ export const parseArgs = (log: ILog) =>
                 "outputCache",
                 "help",
                 "version",
-                "includeDotPaths",
             ],
         })
         .option("migrate", {
@@ -74,7 +65,6 @@ export const parseArgs = (log: ILog) =>
         .alias("allowEmptyTags", ["a", "allow-empty-tags"])
         .alias("outputCache", ["o", "output-cache"])
         .alias("fromCache", ["f", "use-cache"])
-        .alias("includeDotPaths", ["d", "include-dot-paths"])
         .strictOptions()
         .fail((msg, err, yargs) => {
             log.error(msg);

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,11 +216,6 @@ export type Options = {
      */
     includeGlobs: ReadonlyArray<string>;
     /**
-     * Include paths that begin with a dot, e.g. ".gitignore" when parsing
-     * `includeGlobs`.
-     */
-    includeDotPaths: boolean;
-    /**
      * The globs for files that are to be ignored.
      */
     excludeGlobs: ReadonlyArray<string>;


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
`includeDotPaths` was a mistake. It ends up including things like `.git` which is slow and messy. Instead, folks should explicitly opt in each dot path they want instead. So, this basically puts us back to v8 behavior, but with the non-dotfiles features that were added to v9. v9 bad, v10 good.

Issue: XXX-XXXX

## Test plan:
`pnpm test`