### PR TITLE
Don't follow symlinks in glob searches

### DIFF
--- a/.changeset/rotten-deer-begin.md
+++ b/.changeset/rotten-deer-begin.md
@@ -1,0 +1,5 @@
+---
+"checksync": patch
+---
+
+Checksync no longer follows symlinks when doing glob searches

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,6 @@
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
             "program": "${workspaceFolder}/node_modules/jest/bin/jest"
         },
         {
@@ -25,9 +24,8 @@
             "name": "Launch Program",
             "program": "${workspaceFolder}/bin/checksync.dev.js",
             "args": [
-                "-m",
-                ".ka_root",
-                "/Users/jeffyates/khan/webapp/Makefile"
+                "--config",
+                "/Users/jeffyates/khan/webapp/.checksyncrc.json"
             ],
         }
     ]

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.34.2",
-        "fast-glob": "^3.3.2",
+        "fast-glob": "^3.3.3",
         "globals": "^16.0.0",
         "ignore": "^7.0.3",
         "jest": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         specifier: ^7.34.2
         version: 7.37.5(eslint@9.25.1)
       fast-glob:
-        specifier: ^3.3.2
+        specifier: ^3.3.3
         version: 3.3.3
       globals:
         specifier: ^16.0.0

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -430,8 +430,6 @@ Verbose  Exclude globs: [
 ]
 Verbose  Discovered paths: [
     "ROOT_DIR/__examples__/checksums_need_updating/README.md",
-    "ROOT_DIR/__examples__/checksums_need_updating/symlinked/a.js",
-    "ROOT_DIR/__examples__/checksums_need_updating/symlinked/b.py",
     "ROOT_DIR/__examples__/checksums_need_updating/unsymlinked/a.js",
     "ROOT_DIR/__examples__/checksums_need_updating/unsymlinked/b.py",
     "ROOT_DIR/__examples__/checksums_need_updating/unsymlinked/c.jsx"
@@ -7232,7 +7230,6 @@ Verbose  Exclude globs: [
     "**/excluded/**"
 ]
 Verbose  Discovered paths: [
-    "ROOT_DIR/__examples__/remote_tags_match/symlinked/example.jsx",
     "ROOT_DIR/__examples__/remote_tags_match/unsymlinked/example.jsx"
 ]
 Info     Cache written to ROOT_DIR/.integrationtests/remote_tags_match.json"

--- a/src/get-files.ts
+++ b/src/get-files.ts
@@ -52,6 +52,7 @@ export default async function getFiles(
     const paths = await glob([...includeGlobs], {
         onlyFiles: true,
         absolute: true,
+        followSymbolicLinks: false,
         ignore: excludeGlobs as Array<string>, // remove readonly-ness
     });
     const sortedPaths = paths

--- a/src/get-files.ts
+++ b/src/get-files.ts
@@ -36,10 +36,7 @@ export default async function getFiles(
     // files below that directory and that directory's children.
     includeGlobs = includeGlobs.map((pattern: string) =>
         !pattern.includes("*") &&
-        // TODO: Use throwIfNoEntry in lstatSync/lstat to replace need to do
-        // the existence check, once we are on versions of Node that support it.
-        fs.existsSync(pattern) &&
-        fs.lstatSync(pattern).isDirectory()
+        fs.lstatSync(pattern, {throwIfNoEntry: false})?.isDirectory()
             ? `${pattern}/**`
             : pattern,
     );

--- a/src/ignore-file-globs-to-allow-predicate.ts
+++ b/src/ignore-file-globs-to-allow-predicate.ts
@@ -42,6 +42,7 @@ export default async (
                   await glob([...ignoreFileGlobs], {
                       onlyFiles: true,
                       absolute: true,
+                      followSymbolicLinks: false,
                   })
               )
                   // We need to make sure that we apply our ignore files in


### PR DESCRIPTION
## Summary:
This makes sure we don't follow symlinks when searching for ignore files or files. We shouldn't need to follow symlinks as the target of relevant symlinks should be in the codebase being scanned, anyway.

Issue: #2134

## Test plan:
`pnpm test` should pass.
I also ran this against the Khan webapp repo where we were encountering issues and it appears to work.